### PR TITLE
[LC-26] Edit `BlockGenerationScheduler` and logic to reset leader without status check of new leader candidates.

### DIFF
--- a/loopchain/baseservice/block_generation_scheduelr.py
+++ b/loopchain/baseservice/block_generation_scheduelr.py
@@ -28,7 +28,6 @@ class BlockGenerationScheduler(CommonThread):
         self.__schedule_queue = queue.Queue()
 
     def add_schedule(self, schedule):
-        # util.logger.spam(f"BlockGenerationScheduler:add_schedule")
         self.__schedule_queue.put(schedule)
 
     def get_schedule(self):

--- a/loopchain/baseservice/peer_manager.py
+++ b/loopchain/baseservice/peer_manager.py
@@ -356,10 +356,13 @@ class PeerManager:
 
         return leader_peer
 
-    def get_next_leader_peer(self, group_id=None, is_only_alive=False):
+    def get_next_leader_peer(self, group_id=None, current_leader_peer=None, is_only_alive=False):
         util.logger.spam(f"peer_manager:get_next_leader_peer")
-        leader_peer = self.get_leader_peer(group_id, is_complain_to_rs=True)
-        return self.__get_next_peer(leader_peer, group_id, is_only_alive)
+
+        if current_leader_peer:
+            current_leader_peer = self.get_leader_peer(group_id, is_complain_to_rs=True)
+
+        return self.__get_next_peer(current_leader_peer, group_id, is_only_alive)
 
     def __get_next_peer(self, peer, group_id=None, is_only_alive=False):
         if peer is None:

--- a/loopchain/blockchain/block.py
+++ b/loopchain/blockchain/block.py
@@ -111,7 +111,8 @@ class Block:
             "height": self.height,
             "peer_id": self.peer_id,
             "signature": base64.b64encode(self.signature).decode(),
-            "commit_state": self.__commit_state
+            "commit_state": self.__commit_state,
+            "next_leader_peer_id": self.__next_leader_peer_id
         }
         return json.dumps(self.__json_data)
 
@@ -126,7 +127,8 @@ class Block:
             "height": self.height,
             "peer_id": self.peer_id,
             "signature": base64.b64encode(self.signature).decode(),
-            "commit_state": self.__commit_state
+            "commit_state": self.__commit_state,
+            "next_leader_peer_id": self.__next_leader_peer_id
         }
         return json.dumps(self.__json_data)
 
@@ -316,6 +318,7 @@ class Block:
             self.__signature = base64.b64decode(dump_obj['signature'].encode('UTF-8'))
             self.__commit_state = dump_obj['commit_state'] if 'commit_state' in dump_obj else self.__commit_state
             self.block_status = BlockStatus.confirmed
+            self.__next_leader_peer_id = dump_obj['next_leader_peer_id']
         else:
             dump_obj = pickle.loads(block_dumps)
             if type(dump_obj) == Block:

--- a/loopchain/blockchain/block.py
+++ b/loopchain/blockchain/block.py
@@ -111,8 +111,7 @@ class Block:
             "height": self.height,
             "peer_id": self.peer_id,
             "signature": base64.b64encode(self.signature).decode(),
-            "commit_state": self.__commit_state,
-            "next_leader_peer_id": self.__next_leader_peer_id
+            "commit_state": self.__commit_state
         }
         return json.dumps(self.__json_data)
 
@@ -127,8 +126,7 @@ class Block:
             "height": self.height,
             "peer_id": self.peer_id,
             "signature": base64.b64encode(self.signature).decode(),
-            "commit_state": self.__commit_state,
-            "next_leader_peer_id": self.__next_leader_peer_id
+            "commit_state": self.__commit_state
         }
         return json.dumps(self.__json_data)
 
@@ -318,7 +316,6 @@ class Block:
             self.__signature = base64.b64decode(dump_obj['signature'].encode('UTF-8'))
             self.__commit_state = dump_obj['commit_state'] if 'commit_state' in dump_obj else self.__commit_state
             self.block_status = BlockStatus.confirmed
-            self.__next_leader_peer_id = dump_obj['next_leader_peer_id']
         else:
             dump_obj = pickle.loads(block_dumps)
             if type(dump_obj) == Block:
@@ -363,8 +360,8 @@ class Block:
         if block.block_hash != Block.__generate_hash(block):
             raise BlockInValidError('block Hash is not same generate hash')
 
-        leader = channel_service.peer_manager.get_leader_object()
-        if not leader.cert_verifier.verify_hash(block.block_hash, block.signature):
+        block_generator = channel_service.peer_manager.peer_object_list[conf.ALL_GROUP_ID][block.peer_id]
+        if not block_generator.cert_verifier.verify_hash(block.block_hash, block.signature):
             raise BlockInValidError('block signature invalid')
 
         if block.time_stamp == 0:

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -606,10 +606,9 @@ class BlockChain:
                                                   f"That's why Genesis block couldn't be generated.")
 
         block.generate_block()
-        # 제네시스 블럭을 추가 합니다.
+        if conf.CONSENSUS_ALGORITHM == conf.ConsensusAlgorithm.lft:
+            block.next_leader_peer = ObjectManager().channel_service.peer_manager.get_next_leader_peer().peer_id
         self.add_block(block)
-        # 제네시스 블럭의 HASH 값은 af5570f5a1810b7af78caf4bc70a660f0df51e42baf91d4de5b2328de0e83dfc
-        # 으로 일정 합니다.
 
     def __put_block_to_db(self, block_key, block):
         # confirm 블럭

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -606,8 +606,6 @@ class BlockChain:
                                                   f"That's why Genesis block couldn't be generated.")
 
         block.generate_block()
-        if conf.CONSENSUS_ALGORITHM == conf.ConsensusAlgorithm.lft:
-            block.next_leader_peer = ObjectManager().channel_service.peer_manager.get_next_leader_peer().peer_id
         self.add_block(block)
 
     def __put_block_to_db(self, block_key, block):
@@ -773,3 +771,8 @@ class BlockChain:
     def set_last_commit_state(self, height, commit_state):
         self.last_commit_state_height = height
         self.last_commit_state = copy.deepcopy(commit_state)
+
+    def invoke_for_precommit(self, precommit_block: Block):
+        invoke_results = \
+            self.__score_invoke_with_state_integrity(precommit_block, precommit_block.commit_state)
+        self.__add_tx_to_block_db(precommit_block, invoke_results)

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -849,12 +849,12 @@ class ChannelService:
             stub.sync_task().change_block_hash(change_hash_info)
 
     def score_write_precommit_state(self, block: Block):
-        logging.debug(f"call score precommit {ChannelProperty().name} {block.height} {block.block_hash}")
+        logging.debug(f"call score commit {ChannelProperty().name} {block.height} {block.block_hash}")
 
         if util.channel_use_icx(ChannelProperty().name):
             request = {
                 "blockHeight": block.height,
-                "blockHash": block.block_hash,
+                "blockHash": block.block_hash
             }
             request = convert_params(request, ParamType.write_precommit_state)
 

--- a/loopchain/consensus/acceptor.py
+++ b/loopchain/consensus/acceptor.py
@@ -64,7 +64,7 @@ class Acceptor(Subscriber):
         self.__ready_count: dict = {}
         self.__uncommit_block = None
         self.__status = AcceptorStatus.normal
-        self._event_list = [("complete_consensus", self.__callback_complete_consensus)]
+        self._event_list = [(Consensus.EVENT_COMPLETE_CONSENSUS, self.__callback_complete_consensus)]
 
     @property
     def epoch(self):

--- a/loopchain/consensus/consensus.py
+++ b/loopchain/consensus/consensus.py
@@ -32,13 +32,13 @@ class Consensus(CommonThread, Publisher):
     EVENT_COMPLETE_CONSENSUS = "complete_consensus"
     EVENT_MAKE_BLOCK = "make_block"
     EVENT_LEADER_COMPLAIN_F_1 = "leader_complain_f_1"
-    EVENT_LEADER_COMPLAIN_F_2 = "leader_complain_2f_1"
+    EVENT_LEADER_COMPLAIN_2F_1 = "leader_complain_2f_1"
 
     def __init__(self, channel_service: 'ChannelService', channel: str=None, **kwargs):
         Publisher.__init__(self, [
             Consensus.EVENT_COMPLETE_CONSENSUS,
             Consensus.EVENT_LEADER_COMPLAIN_F_1,
-            Consensus.EVENT_LEADER_COMPLAIN_F_2,
+            Consensus.EVENT_LEADER_COMPLAIN_2F_1,
             Consensus.EVENT_MAKE_BLOCK])
         self.channel_name = channel
         self.__channel_service = channel_service
@@ -170,9 +170,6 @@ class Consensus(CommonThread, Publisher):
             self.__last_epoch = self.__epoch
             self.__epoch = None
         elif self.__precommit_block is None and precommit_block is not None:
-            if precommit_block.height > 0:
-                self.__leader_id = precommit_block.peer_id
-                self.__channel_service.reset_leader(precommit_block.next_leader_peer, precommit_block.height)
             self.__precommit_block = precommit_block
 
         if self.__precommit_block is not None:

--- a/loopchain/consensus/consensus.py
+++ b/loopchain/consensus/consensus.py
@@ -28,8 +28,17 @@ from loopchain.baseservice.aging_cache import AgingCache
 
 
 class Consensus(CommonThread, Publisher):
+    EVENT_COMPLETE_CONSENSUS = "complete_consensus"
+    EVENT_MAKE_BLOCK = "make_block"
+    EVENT_LEADER_COMPLAIN_F_1 = "leader_complain_f_1"
+    EVENT_LEADER_COMPLAIN_F_2 = "leader_complain_2f_1"
+
     def __init__(self, channel_service: 'ChannelService', channel: str=None, **kwargs):
-        Publisher.__init__(self, ["complete_consensus", "leader_complain_f_1", "leader_complain_2f_1", "make_block"])
+        Publisher.__init__(self, [
+            Consensus.EVENT_COMPLETE_CONSENSUS,
+            Consensus.EVENT_LEADER_COMPLAIN_F_1,
+            Consensus.EVENT_LEADER_COMPLAIN_F_2,
+            Consensus.EVENT_MAKE_BLOCK])
         self.__channel_service = channel_service
         self.__peer_manager = channel_service.peer_manager
         self.channel_name = channel
@@ -80,7 +89,7 @@ class Consensus(CommonThread, Publisher):
             util.logger.spam(f"hrkim>>>consensus :: create_epoch : precommit height : {self.__precommit_block.height}")
 
         self._notify(
-            event="complete_consensus",
+            event=Consensus.EVENT_COMPLETE_CONSENSUS,
             precommit_block=self.__precommit_block,
             prev_epoch=self.__last_epoch,
             epoch=self.__epoch,
@@ -130,7 +139,7 @@ class Consensus(CommonThread, Publisher):
         while self.is_run():
             time.sleep(sleep_time)
             util.logger.spam(f"---- MAKE BLOCK EVENT ----")
-            self._notify("make_block", tx_queue=self.__tx_queue)
+            self._notify(Consensus.EVENT_MAKE_BLOCK, tx_queue=self.__tx_queue)
 
         logging.info(f"channel({self.channel_name}) Consensus thread Ended.")
 

--- a/loopchain/consensus/consensus.py
+++ b/loopchain/consensus/consensus.py
@@ -16,6 +16,7 @@
 import logging
 import threading
 import time
+from collections import namedtuple
 
 from loopchain import configure as conf
 from loopchain import utils as util
@@ -23,7 +24,7 @@ from loopchain import utils as util
 from loopchain.blockchain import Block, TransactionStatusInQueue
 from loopchain.channel.channel_property import ChannelProperty
 from loopchain.consensus import Publisher, Epoch, EpochStatus
-from loopchain.baseservice import ObjectManager, CommonThread, Timer
+from loopchain.baseservice import ObjectManager, CommonThread, Timer, BlockGenerationScheduler
 from loopchain.baseservice.aging_cache import AgingCache
 
 
@@ -39,15 +40,20 @@ class Consensus(CommonThread, Publisher):
             Consensus.EVENT_LEADER_COMPLAIN_F_1,
             Consensus.EVENT_LEADER_COMPLAIN_F_2,
             Consensus.EVENT_MAKE_BLOCK])
+        self.channel_name = channel
         self.__channel_service = channel_service
         self.__peer_manager = channel_service.peer_manager
-        self.channel_name = channel
         self.__last_epoch: Epoch = None
         self.__precommit_block: Block = None
         self.__epoch: Epoch = None
         self.__leader_id = None
         self.__tx_queue = AgingCache(max_age_seconds=conf.MAX_TX_QUEUE_AGING_SECONDS,
                                      default_item_status=TransactionStatusInQueue.normal)
+        self.__sleep_time = None
+        self.__run_logic = None
+        self.__block_generation_scheduler = BlockGenerationScheduler(self.channel_name)
+
+        self.__init_data()
 
     @property
     def epoch(self):
@@ -69,11 +75,34 @@ class Consensus(CommonThread, Publisher):
     def precommit_block(self, precommit_block):
         self.__precommit_block = precommit_block
 
-    def get_tx_queue(self) -> AgingCache:
-        return self.__tx_queue
+    @property
+    def block_generation_scheduler(self):
+        return self.__block_generation_scheduler
 
-    def add_tx_obj(self, tx):
-        self.__tx_queue[tx.tx_hash] = tx
+    def __init_data(self):
+        self.__init_sleep_time()
+        self.__set_run_logic()
+
+    def __set_run_logic(self):
+        if conf.ALLOW_MAKE_EMPTY_BLOCK:
+            self.__run_logic = self.__create_block_generation_schedule
+        else:
+            self.__run_logic = self.__notify
+
+    def __init_sleep_time(self):
+        if conf.ALLOW_MAKE_EMPTY_BLOCK:
+            self.__sleep_time = conf.INTERVAL_BLOCKGENERATION
+        else:
+            # self.__sleep_time = conf.SLEEP_SECONDS_IN_SERVICE_LOOP
+            self.__sleep_time = 5
+
+    def __create_block_generation_schedule(self):
+        util.logger.spam(f"block_manager.py:__create_block_generation_schedule:: CREATE BLOCK GENERATION SCHEDULE")
+        Schedule = namedtuple("Schedule", "callback kwargs")
+        schedule = Schedule(self._notify, {"event": Consensus.EVENT_MAKE_BLOCK, "tx_queue": self.__tx_queue})
+        self.__block_generation_scheduler.add_schedule(schedule)
+
+        time.sleep(conf.INTERVAL_BLOCKGENERATION)
 
     def __create_epoch(self):
         quorum, complain_quorum = self.__peer_manager.get_quorum()
@@ -95,30 +124,21 @@ class Consensus(CommonThread, Publisher):
             epoch=self.__epoch,
             tx_queue=self.__tx_queue)
 
-    def set_new_leader(self, precommit_block: Block):
-        peer_order_list: dict = self.__peer_manager.peer_order_list[conf.ALL_GROUP_ID]
+    def get_tx_queue(self) -> AgingCache:
+        return self.__tx_queue
 
-        util.logger.spam(f"hrkim==================peer_order_list{peer_order_list}")
-        util.logger.spam(f"hrkim==================current_leader({self.__leader_id})")
-        util.logger.spam(f"hrkim==================precommit_block.height({precommit_block.height})")
+    def add_tx_obj(self, tx):
+        self.__tx_queue[tx.tx_hash] = tx
 
-        new_leader_order = None
-        for order, peer_id in peer_order_list.items():
-            if peer_id == self.__leader_id:
-                util.logger.spam(f"hrkim==================current_leader_order({order})")
-                new_leader_order = order + 1
-                break
+    def start(self):
+        if conf.ALLOW_MAKE_EMPTY_BLOCK:
+            self.__block_generation_scheduler.start()
+        CommonThread.start(self)
 
-        peer_list_size = len(peer_order_list)
-        if peer_list_size < new_leader_order or (self.__precommit_block is None and new_leader_order == peer_list_size):
-            new_leader_order = 1
-
-        new_leader_id = peer_order_list[new_leader_order]
-
-        util.logger.spam(f"hrkim==================new_leader({new_leader_id})/new_leader_order({new_leader_order})")
-
-        self.__channel_service.set_new_leader(new_leader_id, precommit_block.height)
-        self.__leader_id = new_leader_id
+    def stop(self):
+        if conf.ALLOW_MAKE_EMPTY_BLOCK:
+            self.__block_generation_scheduler.stop()
+        CommonThread.stop(self)
 
     def run(self, e: threading.Event):
         """Consensus Thread Loop
@@ -130,16 +150,8 @@ class Consensus(CommonThread, Publisher):
         logging.info(f"channel({self.channel_name}) Consensus thread Start.")
         e.set()
 
-        if conf.ALLOW_MAKE_EMPTY_BLOCK:
-            sleep_time = conf.INTERVAL_BLOCKGENERATION
-        else:
-            # sleep_time = conf.SLEEP_SECONDS_IN_SERVICE_LOOP
-            sleep_time = 2
-
         while self.is_run():
-            time.sleep(sleep_time)
-            util.logger.spam(f"---- MAKE BLOCK EVENT ----")
-            self._notify(Consensus.EVENT_MAKE_BLOCK, tx_queue=self.__tx_queue)
+            self.__run_logic()
 
         logging.info(f"channel({self.channel_name}) Consensus thread Ended.")
 
@@ -160,7 +172,7 @@ class Consensus(CommonThread, Publisher):
         elif self.__precommit_block is None and precommit_block is not None:
             if precommit_block.height > 0:
                 self.__leader_id = precommit_block.peer_id
-                self.set_new_leader(precommit_block)
+                self.__channel_service.reset_leader(precommit_block.next_leader_peer, precommit_block.height)
             self.__precommit_block = precommit_block
 
         if self.__precommit_block is not None:
@@ -191,3 +203,4 @@ class Consensus(CommonThread, Publisher):
             callback_kwargs={"epoch": self.__epoch}
         )
         ObjectManager().channel_service.timer_service.add_timer(timer_key, timer)
+

--- a/loopchain/consensus/proposer.py
+++ b/loopchain/consensus/proposer.py
@@ -20,7 +20,7 @@ import pickle
 from loopchain import configure as conf
 from loopchain.blockchain import *
 from loopchain.baseservice import ObjectManager
-from loopchain.consensus import Subscriber, Epoch
+from loopchain.consensus import Subscriber, Epoch, Consensus
 from loopchain.baseservice.aging_cache import AgingCache
 
 
@@ -43,8 +43,8 @@ class Proposer(Subscriber):
         self.__precommit_block: Block = kwargs.get("precommit_block", None)
         self.__epoch = kwargs.get("epoch", None)
         self._event_list = [
-            ("complete_consensus", self.callback_complete_consensus),
-            ("make_block", self.callback_make_block)
+            (Consensus.EVENT_COMPLETE_CONSENSUS, self.callback_complete_consensus),
+            (Consensus.EVENT_MAKE_BLOCK, self.callback_make_block)
         ]
         self.__block: Block = None
         self.__block_tx_size = 0

--- a/loopchain/consensus/proposer.py
+++ b/loopchain/consensus/proposer.py
@@ -121,7 +121,6 @@ class Proposer(Subscriber):
             self.__block_manager.set_last_commit_state(self.__block.height, self.__block.commit_state)
 
         if block_is_verified:
-            self.__block.next_leader_peer = self.__channel_service.peer_manager.get_next_leader_peer().peer_id
             self.__block.sign(self.__channel_service.peer_auth)
         else:
             self.__throw_out_block(self.__block)

--- a/loopchain/consensus/publisher.py
+++ b/loopchain/consensus/publisher.py
@@ -49,3 +49,5 @@ class Publisher:
     def _notify(self, event: str, **kwargs):
         for callback in self.subscribers[event].values():
             callback(**kwargs)
+
+        return True

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -76,7 +76,7 @@ class BlockManager(CommonThread, Subscriber):
         self.__prev_epoch: Epoch = None
         self.__precommit_block: Block = None
         self.__epoch: Epoch = None
-        self._event_list = [("complete_consensus", self.callback_complete_consensus)]
+        self._event_list = [(Consensus.EVENT_COMPLETE_CONSENSUS, self.callback_complete_consensus)]
         self.set_peer_type(loopchain_pb2.PEER)
         self.name = "loopchain.peer.BlockManager"
         self.__service_status = status_code.Service.online

--- a/loopchain/peer/peer_outer_service.py
+++ b/loopchain/peer/peer_outer_service.py
@@ -476,8 +476,8 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
 
         channel_name = conf.LOOPCHAIN_DEFAULT_CHANNEL if request.channel == '' else request.channel
         channel_stub = StubCollection().channel_stubs[channel_name]
-        response_code, response_message, block = self.await_task(
-            channel_stub.task().get_precommit_block(last_block_height=request.last_block_height))
+        response_code, response_message, block = \
+            channel_stub.sync_task().get_precommit_block(last_block_height=request.last_block_height)
 
         return loopchain_pb2.PrecommitBlockReply(
             response_code=response_code, response_message=response_message, block=block)


### PR DESCRIPTION
 - Edit logic to reset leader without status check of new leader candidates. 
 - Fix the case any block doesn't precommit when blocks are synchronized after a new node joins the network.