### PR TITLE
revert old timer in subscribe(channel_service) for compatibility

### DIFF
--- a/loopchain/baseservice/broadcast_scheduler.py
+++ b/loopchain/baseservice/broadcast_scheduler.py
@@ -329,7 +329,7 @@ class BroadcastScheduler(CommonThread):
             self.stored_tx.put(tx_item)
             duration = conf.SEND_TX_LIST_DURATION
 
-        if TimerService.TIMER_KEY_ADD_TX not in self.__timer_service.timer_list.keys():
+        if TimerService.TIMER_KEY_ADD_TX not in self.__timer_service.timer_list:
             self.__timer_service.add_timer(
                 TimerService.TIMER_KEY_ADD_TX,
                 Timer(

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -18,7 +18,7 @@ import json
 import logging
 
 import websockets
-from websockets.exceptions import InvalidStatusCode
+from websockets.exceptions import InvalidStatusCode, InvalidMessage
 
 from loopchain import configure as conf
 from loopchain.baseservice import TimerService, Timer, ObjectManager
@@ -46,12 +46,12 @@ class NodeSubscriber:
                     await websocket.send(request)
                     await self.__subscribe_loop(websocket)
 
-            except InvalidStatusCode as e:
-                logging.warning(f"websocket subscribe InvalidStatusCode exception, caused by: {e}\n"
+            except (InvalidStatusCode, InvalidMessage) as e:
+                logging.warning(f"websocket subscribe {type(e)} exception, caused by: {e}\n"
                                 f"This target({self.__rs_target}) may not support websocket yet.")
                 raise NotImplementedError
             except Exception as e:
-                logging.error(f"websocket subscribe exception, caused by: {e}")
+                logging.error(f"websocket subscribe exception, caused by: {type(e)}, {e}")
                 await self.__start_shutdown_timer()
                 await asyncio.sleep(conf.SUBSCRIBE_RETRY_TIMER)
 

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -69,7 +69,7 @@ class NodeSubscriber:
 
     async def __start_shutdown_timer(self):
         timer_key = TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE
-        if timer_key not in ObjectManager().channel_service.timer_service.timer_list.keys():
+        if timer_key not in ObjectManager().channel_service.timer_service.timer_list:
             error = f"Shutdown by Subscribe retry timeout({conf.SHUTDOWN_TIMER} sec)"
             ObjectManager().channel_service.timer_service.add_timer(
                 timer_key,
@@ -83,7 +83,7 @@ class NodeSubscriber:
 
     async def __stop_shutdown_timer(self):
         timer_key = TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE
-        if timer_key in ObjectManager().channel_service.timer_service.timer_list.keys():
+        if timer_key in ObjectManager().channel_service.timer_service.timer_list:
             ObjectManager().channel_service.timer_service.stop_timer(timer_key)
 
     async def __add_confirmed_block(self, block_json: str):

--- a/loopchain/baseservice/rest_stub_manager.py
+++ b/loopchain/baseservice/rest_stub_manager.py
@@ -116,7 +116,7 @@ class RestStubManager:
             logging.warning(f"REST call fail method_name({method_name}), caused by : {e}")
             raise e
 
-    def call_async(self, method_name, message, call_back=None, timeout=None, is_stub_reuse=True):
+    def call_async(self, method_name, message=None, call_back=None, timeout=None, is_stub_reuse=True):
         future = self.__executor.submit(self.call, method_name, message, timeout, is_stub_reuse)
         if call_back:
             future.add_done_callback(call_back)

--- a/loopchain/baseservice/timer_service.py
+++ b/loopchain/baseservice/timer_service.py
@@ -80,7 +80,10 @@ class Timer:
         """
         if off_type is OffType.time_out:
             logging.debug(f'timer({self.__target}) is turned off by timeout')
-            self.__callback(**self.__kwargs)
+            if asyncio.iscoroutinefunction(self.__callback):
+                asyncio.get_event_loop().create_task(self.__callback(**self.__kwargs))
+            else:
+                self.__callback(**self.__kwargs)
 
     def __repr__(self):
         return f"{self.__callback}, {self.remain_time()}"
@@ -89,6 +92,7 @@ class Timer:
 class TimerService(CommonThread):
     """timer service"""
 
+    TIMER_KEY_GET_LAST_BLOCK_KEEP_CITIZEN_SUBSCRIPTION = "TIMER_KEY_GET_LAST_BLOCK_KEEP_CITIZEN_SUBSCRIPTION"
     TIMER_KEY_BLOCK_HEIGHT_SYNC = "TIMER_KEY_BLOCK_HEIGHT_SYNC"
     TIMER_KEY_ADD_TX = "TIMER_KEY_ADD_TX"
     TIMER_KEY_SUBSCRIBE = "TIMER_KEY_SUBSCRIBE"

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -309,7 +309,7 @@ class ChannelInnerTask:
                               f"already synced block height({confirmed_block.height})")
             response_code = message_code.Response.success
             # stop subscribe timer
-            if TimerService.TIMER_KEY_SUBSCRIBE in self._channel_service.timer_service.timer_list.keys():
+            if TimerService.TIMER_KEY_SUBSCRIBE in self._channel_service.timer_service.timer_list:
                 self._channel_service.timer_service.stop_timer(TimerService.TIMER_KEY_SUBSCRIBE)
         except Exception as e:
             logging.error(f"announce confirmed block error : {e}")

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -497,20 +497,90 @@ class ChannelService:
                                                block_height=self.block_manager.get_blockchain().block_height)
 
     async def __subscribe_call_by_rest_stub(self, rs_rest_stub):
-        if conf.REST_SSL_TYPE == conf.SSLAuthType.none:
-            peer_target = ChannelProperty().rest_target
+        response = {'response_code': message_code.Response.fail,
+                    'message': message_code.get_response_msg(message_code.Response.fail)}
+
+        try:
+            if conf.REST_SSL_TYPE == conf.SSLAuthType.none:
+                peer_target = ChannelProperty().rest_target
+            else:
+                peer_target = f"https://{ChannelProperty().rest_target}"
+            response = rs_rest_stub.call(
+                "Subscribe", {
+                    'channel': ChannelProperty().name,
+                    'peer_target': peer_target
+                }
+            )
+
+        except Exception as e:
+            logging.warning(f"Due to Subscription fail to RadioStation(mother peer), "
+                            f"automatically retrying subscribe call")
+
+        if response['response_code'] == message_code.Response.success:
+            if TimerService.TIMER_KEY_SUBSCRIBE in self.__timer_service.timer_list.keys():
+                self.__timer_service.stop_timer(TimerService.TIMER_KEY_SUBSCRIBE)
+                logging.debug(f"Subscription to RadioStation(mother peer) is successful.")
+
+            if TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE in self.__timer_service.timer_list.keys():
+                self.__timer_service.stop_timer(TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE)
+
+            # start next get_status timer
+            timer_key = TimerService.TIMER_KEY_GET_LAST_BLOCK_KEEP_CITIZEN_SUBSCRIPTION
+            if timer_key not in self.__timer_service.timer_list.keys():
+                util.logger.spam(f"add timer for check_block_height_call to radiostation...")
+                self.__timer_service.add_timer(
+                    timer_key,
+                    Timer(
+                        target=timer_key,
+                        duration=conf.GET_LAST_BLOCK_TIMER,
+                        is_repeat=True,
+                        callback=self.__check_block_height_call_to_rs_stub,
+                        callback_kwargs={"rs_rest_stub": rs_rest_stub}
+                    )
+                )
         else:
-            peer_target = f"https://{ChannelProperty().rest_target}"
-        response = rs_rest_stub.call(
-            "Subscribe", {
-                'channel': ChannelProperty().name,
-                'peer_target': peer_target
-            }
-        )
-        if response['response_code'] != message_code.Response.success:
-            error = f"subscribe fail to peer_target({ChannelProperty().radio_station_target}) " \
-                    f"reason({response['message']})"
-            await StubCollection().peer_stub.async_task().stop(message=error)
+            timer_key = TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE
+            if timer_key not in self.__timer_service.timer_list.keys():
+                error = f"Shutdown by Subscribe retry timeout({conf.SHUTDOWN_TIMER})"
+                self.__timer_service.add_timer(
+                    timer_key,
+                    Timer(
+                        target=timer_key,
+                        duration=conf.SHUTDOWN_TIMER,
+                        callback=self.shutdown_peer,
+                        callback_kwargs={"message": error}
+                    )
+                )
+
+        return response
+
+    def __check_block_height_call_to_rs_stub(self, **kwargs):
+        rs_rest_stub = kwargs.get("rs_rest_stub", None)
+        try:
+            last_block = rs_rest_stub.call("GetLastBlock")
+            if last_block['height'] <= self.__block_manager.get_blockchain().block_height:
+                return
+            else:
+                # citizen needs additional block or connected to problematic peer.
+                raise Exception
+        except Exception as e:
+            timer_key = TimerService.TIMER_KEY_GET_LAST_BLOCK_KEEP_CITIZEN_SUBSCRIPTION
+            if timer_key in self.__timer_service.timer_list.keys():
+                util.logger.spam(f"stop timer for check_block_height_call to radiostation...")
+                self.__timer_service.stop_timer(timer_key)
+
+            timer_key = TimerService.TIMER_KEY_SUBSCRIBE
+            if timer_key not in self.__timer_service.timer_list.keys():
+                self.__timer_service.add_timer(
+                    timer_key,
+                    Timer(
+                        target=timer_key,
+                        duration=conf.SUBSCRIBE_RETRY_TIMER,
+                        is_repeat=True,
+                        callback=self.__subscribe_call_by_websocket,
+                        callback_kwargs={"rs_rest_stub": rs_rest_stub}
+                    )
+                )
 
     def shutdown_peer(self, **kwargs):
         logging.debug(f"channel_service:shutdown_peer")

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -432,7 +432,7 @@ class ChannelService:
             timeout=conf.CONNECTION_TIMEOUT_TO_RS)
 
         # start next ConnectPeer timer
-        if TimerService.TIMER_KEY_CONNECT_PEER not in self.__timer_service.timer_list.keys():
+        if TimerService.TIMER_KEY_CONNECT_PEER not in self.__timer_service.timer_list:
             self.__timer_service.add_timer(
                 TimerService.TIMER_KEY_CONNECT_PEER,
                 Timer(
@@ -497,15 +497,14 @@ class ChannelService:
                                                block_height=self.block_manager.get_blockchain().block_height)
 
     async def __subscribe_call_by_rest_stub(self, rs_rest_stub):
-        response = {'response_code': message_code.Response.fail,
-                    'message': message_code.get_response_msg(message_code.Response.fail)}
+        if conf.REST_SSL_TYPE == conf.SSLAuthType.none:
+            peer_target = ChannelProperty().rest_target
+        else:
+            peer_target = f"https://{ChannelProperty().rest_target}"
 
+        response = None
         try:
-            if conf.REST_SSL_TYPE == conf.SSLAuthType.none:
-                peer_target = ChannelProperty().rest_target
-            else:
-                peer_target = f"https://{ChannelProperty().rest_target}"
-            response = rs_rest_stub.call(
+            response = await rs_rest_stub.call_async(
                 "Subscribe", {
                     'channel': ChannelProperty().name,
                     'peer_target': peer_target
@@ -516,17 +515,17 @@ class ChannelService:
             logging.warning(f"Due to Subscription fail to RadioStation(mother peer), "
                             f"automatically retrying subscribe call")
 
-        if response['response_code'] == message_code.Response.success:
-            if TimerService.TIMER_KEY_SUBSCRIBE in self.__timer_service.timer_list.keys():
+        if response and response['response_code'] == message_code.Response.success:
+            if TimerService.TIMER_KEY_SUBSCRIBE in self.__timer_service.timer_list:
                 self.__timer_service.stop_timer(TimerService.TIMER_KEY_SUBSCRIBE)
                 logging.debug(f"Subscription to RadioStation(mother peer) is successful.")
 
-            if TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE in self.__timer_service.timer_list.keys():
+            if TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE in self.__timer_service.timer_list:
                 self.__timer_service.stop_timer(TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE)
 
             # start next get_status timer
             timer_key = TimerService.TIMER_KEY_GET_LAST_BLOCK_KEEP_CITIZEN_SUBSCRIPTION
-            if timer_key not in self.__timer_service.timer_list.keys():
+            if timer_key not in self.__timer_service.timer_list:
                 util.logger.spam(f"add timer for check_block_height_call to radiostation...")
                 self.__timer_service.add_timer(
                     timer_key,
@@ -540,7 +539,7 @@ class ChannelService:
                 )
         else:
             timer_key = TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE
-            if timer_key not in self.__timer_service.timer_list.keys():
+            if timer_key not in self.__timer_service.timer_list:
                 error = f"Shutdown by Subscribe retry timeout({conf.SHUTDOWN_TIMER})"
                 self.__timer_service.add_timer(
                     timer_key,
@@ -552,35 +551,29 @@ class ChannelService:
                     )
                 )
 
-        return response
-
-    def __check_block_height_call_to_rs_stub(self, **kwargs):
+    async def __check_block_height_call_to_rs_stub(self, **kwargs):
         rs_rest_stub = kwargs.get("rs_rest_stub", None)
-        try:
-            last_block = rs_rest_stub.call("GetLastBlock")
-            if last_block['height'] <= self.__block_manager.get_blockchain().block_height:
-                return
-            else:
-                # citizen needs additional block or connected to problematic peer.
-                raise Exception
-        except Exception as e:
-            timer_key = TimerService.TIMER_KEY_GET_LAST_BLOCK_KEEP_CITIZEN_SUBSCRIPTION
-            if timer_key in self.__timer_service.timer_list.keys():
-                util.logger.spam(f"stop timer for check_block_height_call to radiostation...")
-                self.__timer_service.stop_timer(timer_key)
+        last_block = await rs_rest_stub.call_async("GetLastBlock")
+        if last_block['height'] <= self.__block_manager.get_blockchain().block_height:
+            return
 
-            timer_key = TimerService.TIMER_KEY_SUBSCRIBE
-            if timer_key not in self.__timer_service.timer_list.keys():
-                self.__timer_service.add_timer(
-                    timer_key,
-                    Timer(
-                        target=timer_key,
-                        duration=conf.SUBSCRIBE_RETRY_TIMER,
-                        is_repeat=True,
-                        callback=self.__subscribe_call_by_websocket,
-                        callback_kwargs={"rs_rest_stub": rs_rest_stub}
-                    )
+        timer_key = TimerService.TIMER_KEY_GET_LAST_BLOCK_KEEP_CITIZEN_SUBSCRIPTION
+        if timer_key in self.__timer_service.timer_list:
+            util.logger.spam(f"stop timer for check_block_height_call to radiostation...")
+            self.__timer_service.stop_timer(timer_key)
+
+        timer_key = TimerService.TIMER_KEY_SUBSCRIBE
+        if timer_key not in self.__timer_service.timer_list:
+            self.__timer_service.add_timer(
+                timer_key,
+                Timer(
+                    target=timer_key,
+                    duration=conf.SUBSCRIBE_RETRY_TIMER,
+                    is_repeat=True,
+                    callback=self.__subscribe_call_from_citizen,
+                    callback_kwargs={"rs_rest_stub": rs_rest_stub}
                 )
+            )
 
     def shutdown_peer(self, **kwargs):
         logging.debug(f"channel_service:shutdown_peer")

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -442,7 +442,7 @@ class BlockManager(Subscriber):
         timer_key = TimerService.TIMER_KEY_BLOCK_HEIGHT_SYNC
         timer_service: TimerService = self.__channel_service.timer_service
 
-        if timer_key not in timer_service.timer_list.keys():
+        if timer_key not in timer_service.timer_list:
             util.logger.spam(f"add timer for block_request_call to radiostation...")
             timer_service.add_timer(
                 timer_key,
@@ -458,14 +458,14 @@ class BlockManager(Subscriber):
     def stop_block_height_sync_timer(self):
         timer_key = TimerService.TIMER_KEY_BLOCK_HEIGHT_SYNC
         timer_service: TimerService = self.__channel_service.timer_service
-        if timer_key in timer_service.timer_list.keys():
+        if timer_key in timer_service.timer_list:
             timer_service.stop_timer(timer_key)
 
     def start_block_generate_timer(self):
         timer_key = TimerService.TIMER_KEY_BLOCK_GENERATE
         timer_service: TimerService = self.__channel_service.timer_service
 
-        if timer_key not in timer_service.timer_list.keys():
+        if timer_key not in timer_service.timer_list:
             self.__consensus_algorithm = ConsensusSiever(self)
             util.logger.spam(f"add timer block generate")
             timer_service.add_timer(
@@ -481,7 +481,7 @@ class BlockManager(Subscriber):
     def stop_block_generate_timer(self):
         timer_key = TimerService.TIMER_KEY_BLOCK_GENERATE
         timer_service: TimerService = self.__channel_service.timer_service
-        if timer_key in timer_service.timer_list.keys():
+        if timer_key in timer_service.timer_list:
             timer_service.stop_timer(timer_key)
 
     def __block_height_sync(self, target_peer_stub=None, target_height=None):

--- a/loopchain/radiostation/rs_outer_service.py
+++ b/loopchain/radiostation/rs_outer_service.py
@@ -206,7 +206,7 @@ class OuterService(loopchain_pb2_grpc.RadioStationServicer):
 
         if conf.ENABLE_RADIOSTATION_HEARTBEAT:
             timer_key = f"{TimerService.TIMER_KEY_RS_HEARTBEAT}_{request.channel}"
-            if timer_key not in ObjectManager().rs_service.timer_service.timer_list.keys():
+            if timer_key not in ObjectManager().rs_service.timer_service.timer_list:
                 ObjectManager().rs_service.timer_service.add_timer(
                     timer_key,
                     Timer(


### PR DESCRIPTION
Supports backward compatibility so that citizen node can subscribe continuously even it's disconnected from previous versions of the network.