### PR TITLE
[LC-71] Block Version System - API bug

### DIFF
--- a/cli_tools/icx_test/icx_wallet.py
+++ b/cli_tools/icx_test/icx_wallet.py
@@ -60,7 +60,7 @@ class IcxWallet:
         icx_origin["method"] = "icx_sendTransaction"
         icx_origin["id"] = random.randrange(0, 100000)
         icx_origin["params"] = params
-        self.__last_tx_hash = tx_hash
+        self.__last_tx_hash = tx_hash.hex_0x()
         if self.is_logging:
             logging.debug(f"icx_sendTransaction params for v2: {params}")
 
@@ -85,6 +85,7 @@ class IcxWallet:
         if self.is_logging:
             logging.debug(f"icx_sendTransaction params for v3: {params}")
 
+        self.__last_tx_hash = Hash32(hash_for_sign).hex_0x()
         icx_origin = dict()
         icx_origin["jsonrpc"] = "2.0"
         icx_origin["method"] = "icx_sendTransaction"

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -397,7 +397,7 @@ class BlockChain:
                     logging.warning(f"blockchain:__precommit_tx::KeyError:There is no tx by hash({tx_hash})")
 
     def __save_tx_by_address(self, tx: 'Transaction'):
-        address = tx.from_address.hex()
+        address = tx.from_address.hex_hx()
         return self.add_tx_to_list_by_address(address, tx.hash.hex())
 
     def __save_tx_by_address_pass(self, tx):


### PR DESCRIPTION
### Bugs
- v2 - icx_getTransactionByAddress
  - The cause is that Addresses were stored without prefix(hx)
- v2 - icx_getTransactionResult
  - The problem is that icx_wallet cached binary value, not string(ex. "0x1212")