### PR TITLE
RC1.23.1

### DIFF
--- a/loopchain/blockchain/blocks/__init__.py
+++ b/loopchain/blockchain/blocks/__init__.py
@@ -3,3 +3,5 @@ from .block_builder import BlockBuilder
 from .block_serializer import BlockSerializer
 from .block_verifier import BlockVerifier
 from .block_versions import BlockVersions
+
+from . import v0_1a

--- a/loopchain/blockchain/blocks/block_verifier.py
+++ b/loopchain/blockchain/blocks/block_verifier.py
@@ -2,7 +2,7 @@ import hashlib
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Callable
 from secp256k1 import PrivateKey, PublicKey
-from .. import Address
+from .. import ExternalAddress
 
 if TYPE_CHECKING:
     from . import Block
@@ -36,7 +36,7 @@ class BlockVerifier(ABC):
         expect_address = hash_pub[-20:]
         if expect_address != block.header.peer_id:
             raise RuntimeError(f"block peer id {block.header.peer_id.hex_xx()}, "
-                               f"expected {Address(expect_address).hex_xx()}")
+                               f"expected {ExternalAddress(expect_address).hex_xx()}")
 
     @classmethod
     def new(cls, version: str) -> 'BlockVerifier':

--- a/loopchain/blockchain/blocks/v0_1a/block_serializer.py
+++ b/loopchain/blockchain/blocks/v0_1a/block_serializer.py
@@ -28,7 +28,7 @@ class BlockSerializer(BaseBlockSerializer):
             "confirmed_transaction_list": transactions,
             "block_hash": header.hash.hex(),
             "height": header.height,
-            "peer_id": header.peer_id.hex() if header.peer_id else '',
+            "peer_id": header.peer_id.hex_hx() if header.peer_id else '',
             "signature": header.signature.to_base64str() if header.signature else '',
             "commit_state": header.commit_state
         }

--- a/loopchain/blockchain/blocks/v0_1a/block_verifier.py
+++ b/loopchain/blockchain/blocks/v0_1a/block_verifier.py
@@ -1,7 +1,7 @@
 from typing import TYPE_CHECKING
 from . import BlockBuilder
 from .. import BlockVerifier as BaseBlockVerifier
-from ... import TransactionVerifier
+from ... import TransactionVerifier, TransactionVersions
 
 if TYPE_CHECKING:
     from . import BlockHeader, BlockBody
@@ -51,8 +51,9 @@ class BlockVerifier(BaseBlockVerifier):
         return invoke_result
 
     def verify_transactions(self, block: 'Block', blockchain=None):
+        tx_versions = TransactionVersions()
         for tx in block.body.transactions.values():
-            tv = TransactionVerifier.new(tx.version, 0)
+            tv = TransactionVerifier.new(tx.version, tx_versions.get_hash_generator_version(tx.version))
             tv.verify(tx, blockchain)
 
     def verify_by_prev_block(self, block: 'Block', prev_block: 'Block'):

--- a/loopchain/blockchain/transactions/genesis/transaction_verifier.py
+++ b/loopchain/blockchain/transactions/genesis/transaction_verifier.py
@@ -15,6 +15,9 @@ class TransactionVerifier(BaseTransactionVerifier):
         self._tx_serializer = TransactionSerializer(hash_generator_version)
 
     def verify(self, tx: 'Transaction', blockchain=None):
+        self.verify_loosely(tx, blockchain)
+
+    def verify_loosely(self, tx: 'Transaction', blockchain=None):
         self.verify_hash(tx)
         self.verify_accounts(tx)
         if blockchain:

--- a/loopchain/blockchain/transactions/v2/transaction.py
+++ b/loopchain/blockchain/transactions/v2/transaction.py
@@ -1,6 +1,11 @@
 from dataclasses import dataclass
 from .. import Transaction as BaseTransition
 from ... import Address
+from typing import TYPE_CHECKING, Mapping
+from types import MappingProxyType
+
+if TYPE_CHECKING:
+    from ... import Hash32, Signature
 
 
 @dataclass(frozen=True)
@@ -11,8 +16,22 @@ class Transaction(BaseTransition):
     fee: str
     nonce: str
 
+    extra: Mapping[str, str]
     method = "icx_sendTransaction"
     version = "0x2"
+
+    def __init__(self, hash: 'Hash32', signature: 'Signature', timestamp: int,
+                 from_address: 'Address', to_address: 'Address',
+                 value: str, fee: str, nonce: str, extra: Mapping[str, str]):
+        super().__init__(hash, signature, timestamp)
+
+        object.__setattr__(self, "from_address", from_address)
+        object.__setattr__(self, "to_address", to_address)
+        object.__setattr__(self, "value", value)
+        object.__setattr__(self, "fee", fee)
+        object.__setattr__(self, "nonce", nonce)
+
+        object.__setattr__(self, "extra", MappingProxyType(dict(extra)))
 
 
 HASH_SALT = "icx_sendTransaction"

--- a/loopchain/blockchain/transactions/v2/transaction.py
+++ b/loopchain/blockchain/transactions/v2/transaction.py
@@ -9,7 +9,7 @@ class Transaction(BaseTransition):
     to_address: Address
     value: int
     fee: int
-    nonce: int
+    nonce: str
 
     method = "icx_sendTransaction"
     version = "0x2"

--- a/loopchain/blockchain/transactions/v2/transaction.py
+++ b/loopchain/blockchain/transactions/v2/transaction.py
@@ -7,8 +7,8 @@ from ... import Address
 class Transaction(BaseTransition):
     from_address: Address
     to_address: Address
-    value: int
-    fee: int
+    value: str
+    fee: str
     nonce: str
 
     method = "icx_sendTransaction"

--- a/loopchain/blockchain/transactions/v2/transaction_builder.py
+++ b/loopchain/blockchain/transactions/v2/transaction_builder.py
@@ -21,7 +21,7 @@ class TransactionBuilder(BaseTransactionBuilder):
         self.to_address: 'Address' = None
         self.value: int = None
         self.fee: int = ICX_FEE
-        self.nonce = None
+        self.nonce: str = None
 
         # Attributes to be assigned(optional)
         self.fixed_timestamp: int = None
@@ -63,6 +63,6 @@ class TransactionBuilder(BaseTransactionBuilder):
             "timestamp": str(self._timestamp)
         }
         if self.nonce is not None:
-            params["nonce"] = str(self.nonce)
+            params["nonce"] = self.nonce
 
         return Hash32(self._hash_generator.generate_hash(params))

--- a/loopchain/blockchain/transactions/v2/transaction_builder.py
+++ b/loopchain/blockchain/transactions/v2/transaction_builder.py
@@ -63,6 +63,6 @@ class TransactionBuilder(BaseTransactionBuilder):
             "timestamp": str(self._timestamp)
         }
         if self.nonce is not None:
-            params["nonce"] = hex(self.nonce)
+            params["nonce"] = str(self.nonce)
 
         return Hash32(self._hash_generator.generate_hash(params))

--- a/loopchain/blockchain/transactions/v2/transaction_serializer.py
+++ b/loopchain/blockchain/transactions/v2/transaction_serializer.py
@@ -10,8 +10,8 @@ class TransactionSerializer(BaseTransactionSerializer):
         params = {
             "from": tx.from_address.hex_xx(),
             "to": tx.to_address.hex_xx(),
-            "value": hex(tx.value),
-            "fee": hex(tx.fee)
+            "value": tx.value,
+            "fee": tx.fee
         }
         if tx.timestamp is not None:
             params['timestamp'] = str(tx.timestamp)
@@ -38,8 +38,8 @@ class TransactionSerializer(BaseTransactionSerializer):
             timestamp=int(timestamp) if timestamp is not None else None,
             from_address=Address.fromhex(tx_data['from']),
             to_address=Address.fromhex(tx_data['to']),
-            value=int(tx_data['value'], 16),
-            fee=int(tx_data['fee'], 16),
+            value=tx_data['value'],
+            fee=tx_data['fee'],
             nonce=nonce
         )
 

--- a/loopchain/blockchain/transactions/v2/transaction_serializer.py
+++ b/loopchain/blockchain/transactions/v2/transaction_serializer.py
@@ -16,7 +16,7 @@ class TransactionSerializer(BaseTransactionSerializer):
         if tx.timestamp is not None:
             params['timestamp'] = str(tx.timestamp)
         if tx.nonce is not None:
-            params['nonce'] = str(tx.nonce)
+            params['nonce'] = tx.nonce
         return params
 
     def to_raw_data(self, tx: 'Transaction'):
@@ -40,7 +40,7 @@ class TransactionSerializer(BaseTransactionSerializer):
             to_address=Address.fromhex(tx_data['to']),
             value=int(tx_data['value'], 16),
             fee=int(tx_data['fee'], 16),
-            nonce=int(nonce) if nonce is not None else None
+            nonce=nonce
         )
 
     def get_hash(self, tx_dumped: dict) -> str:

--- a/loopchain/blockchain/transactions/v2/transaction_serializer.py
+++ b/loopchain/blockchain/transactions/v2/transaction_serializer.py
@@ -11,9 +11,10 @@ class TransactionSerializer(BaseTransactionSerializer):
             "from": tx.from_address.hex_xx(),
             "to": tx.to_address.hex_xx(),
             "value": hex(tx.value),
-            "fee": hex(tx.fee),
-            "timestamp": str(tx.timestamp)
+            "fee": hex(tx.fee)
         }
+        if tx.timestamp is not None:
+            params['timestamp'] = str(tx.timestamp)
         if tx.nonce is not None:
             params['nonce'] = hex(tx.nonce)
         return params
@@ -29,16 +30,17 @@ class TransactionSerializer(BaseTransactionSerializer):
 
     def from_(self, tx_data: dict) -> 'Transaction':
         nonce = tx_data.get('nonce')
+        timestamp = tx_data.get('timestamp')
 
         return Transaction(
             hash=Hash32.fromhex(tx_data['tx_hash']),
             signature=Signature.from_base64str(tx_data['signature']),
-            timestamp=int(tx_data['timestamp']),
+            timestamp=int(timestamp) if timestamp is not None else None,
             from_address=Address.fromhex(tx_data['from']),
             to_address=Address.fromhex(tx_data['to']),
             value=int(tx_data['value'], 16),
             fee=int(tx_data['fee'], 16),
-            nonce=int(nonce, 16) if nonce else None
+            nonce=int(nonce, 16) if nonce is not None else None
         )
 
     def get_hash(self, tx_dumped: dict) -> str:

--- a/loopchain/blockchain/transactions/v2/transaction_serializer.py
+++ b/loopchain/blockchain/transactions/v2/transaction_serializer.py
@@ -17,6 +17,8 @@ class TransactionSerializer(BaseTransactionSerializer):
             params['timestamp'] = str(tx.timestamp)
         if tx.nonce is not None:
             params['nonce'] = tx.nonce
+
+        params.update(tx.extra)
         return params
 
     def to_raw_data(self, tx: 'Transaction'):
@@ -29,18 +31,29 @@ class TransactionSerializer(BaseTransactionSerializer):
         return self.to_raw_data(tx)
 
     def from_(self, tx_data: dict) -> 'Transaction':
-        nonce = tx_data.get('nonce')
-        timestamp = tx_data.get('timestamp')
+        tx_data = dict(tx_data)
+        tx_data.pop('method', None)
+
+        hash = tx_data.pop('tx_hash', None)
+        signature = tx_data.pop('signature', None)
+        timestamp = tx_data.pop('timestamp', None)
+        from_address = tx_data.pop('from', None)
+        to_address = tx_data.pop('to', None)
+        value = tx_data.pop('value', None)
+        fee = tx_data.pop('fee', None)
+        nonce = tx_data.pop('nonce', None)
+        extra = tx_data
 
         return Transaction(
-            hash=Hash32.fromhex(tx_data['tx_hash']),
-            signature=Signature.from_base64str(tx_data['signature']),
+            hash=Hash32.fromhex(hash),
+            signature=Signature.from_base64str(signature),
             timestamp=int(timestamp) if timestamp is not None else None,
-            from_address=Address.fromhex(tx_data['from']),
-            to_address=Address.fromhex(tx_data['to']),
-            value=tx_data['value'],
-            fee=tx_data['fee'],
-            nonce=nonce
+            from_address=Address.fromhex(from_address),
+            to_address=Address.fromhex(to_address),
+            value=value,
+            fee=fee,
+            nonce=nonce,
+            extra=extra
         )
 
     def get_hash(self, tx_dumped: dict) -> str:

--- a/loopchain/blockchain/transactions/v2/transaction_serializer.py
+++ b/loopchain/blockchain/transactions/v2/transaction_serializer.py
@@ -16,7 +16,7 @@ class TransactionSerializer(BaseTransactionSerializer):
         if tx.timestamp is not None:
             params['timestamp'] = str(tx.timestamp)
         if tx.nonce is not None:
-            params['nonce'] = hex(tx.nonce)
+            params['nonce'] = str(tx.nonce)
         return params
 
     def to_raw_data(self, tx: 'Transaction'):
@@ -40,7 +40,7 @@ class TransactionSerializer(BaseTransactionSerializer):
             to_address=Address.fromhex(tx_data['to']),
             value=int(tx_data['value'], 16),
             fee=int(tx_data['fee'], 16),
-            nonce=int(nonce, 16) if nonce is not None else None
+            nonce=int(nonce) if nonce is not None else None
         )
 
     def get_hash(self, tx_dumped: dict) -> str:

--- a/loopchain/blockchain/transactions/v2/transaction_verifier.py
+++ b/loopchain/blockchain/transactions/v2/transaction_verifier.py
@@ -1,6 +1,7 @@
 from typing import TYPE_CHECKING
 from . import TransactionSerializer, HASH_SALT
 from .. import TransactionVerifier as BaseTransactionVerifier
+from ... import MalformedAddress
 
 if TYPE_CHECKING:
     from . import Transaction
@@ -14,6 +15,15 @@ class TransactionVerifier(BaseTransactionVerifier):
         self._tx_serializer = TransactionSerializer(hash_generator_version)
 
     def verify(self, tx: 'Transaction', blockchain=None):
+        if isinstance(tx.to_address, MalformedAddress):
+            raise RuntimeError
+
+        if isinstance(tx.from_address, MalformedAddress):
+            raise RuntimeError
+
+        self.verify_loosely(tx, blockchain)
+
+    def verify_loosely(self, tx: 'Transaction', blockchain=None):
         self.verify_hash(tx)
         self.verify_signature(tx)
         if blockchain:

--- a/loopchain/blockchain/transactions/v3/transaction_serializer.py
+++ b/loopchain/blockchain/transactions/v3/transaction_serializer.py
@@ -24,7 +24,7 @@ class TransactionSerializer(BaseTransactionSerializer):
 
         if tx.data is not None and tx.data_type is not None:
             if isinstance(tx.data, str):
-                params["data"] = tx.data.encode('utf-8').hex()
+                params["data"] = tx.data
             else:
                 params["data"] = tx.data
             params["dataType"] = tx.data_type
@@ -51,10 +51,6 @@ class TransactionSerializer(BaseTransactionSerializer):
         if nonce is not None:
             nonce = int(nonce, 16)
 
-        data = tx_data.get('data')
-        if data is not None and isinstance(data, str):
-            data = bytes.fromhex(data).decode('utf-8')
-
         value = tx_data.get('value')
         if value is not None:
             value = int(value, 16)
@@ -70,7 +66,7 @@ class TransactionSerializer(BaseTransactionSerializer):
             nonce=nonce,
             nid=int(tx_data['nid'], 16),
             data_type=tx_data.get('dataType'),
-            data=data
+            data=tx_data.get('data')
         )
 
     def get_hash(self, tx_dumped: dict) -> str:

--- a/loopchain/blockchain/transactions/v3/transaction_verifier.py
+++ b/loopchain/blockchain/transactions/v3/transaction_verifier.py
@@ -14,6 +14,9 @@ class TransactionVerifier(BaseTransactionVerifier):
         self._tx_serializer = TransactionSerializer(hash_generator_version)
 
     def verify(self, tx: 'Transaction', blockchain=None):
+        self.verify_loosely(tx, blockchain)
+
+    def verify_loosely(self, tx: 'Transaction', blockchain=None):
         self.verify_hash(tx)
         self.verify_signature(tx)
         if blockchain:

--- a/loopchain/blockchain/types.py
+++ b/loopchain/blockchain/types.py
@@ -51,7 +51,7 @@ class Address(Bytes, metaclass=ABCMeta):
             return super().fromhex(value)
 
         prefix, contents = value[:2], value[2:]
-        if len(contents) == cls.size * 2:
+        if len(contents) == cls.size * 2 and contents.lower() == contents:
             if prefix == ContractAddress.prefix:
                 return ContractAddress(bytes.fromhex(contents))
 

--- a/loopchain/blockchain/types.py
+++ b/loopchain/blockchain/types.py
@@ -4,13 +4,13 @@ from typing import Union
 from abc import ABCMeta
 
 
-class FixedBytes(bytes):
+class Bytes(bytes):
     size = None
     prefix = None
 
     def __new__(cls, *args, **kwargs):
         self = super().__new__(cls, *args, **kwargs)
-        if len(self) != cls.size:
+        if cls.size is not None and cls.size != len(self):
             raise RuntimeError
 
         return self
@@ -31,7 +31,7 @@ class FixedBytes(bytes):
         return cls(result)
 
 
-class Hash32(FixedBytes):
+class Hash32(Bytes):
     size = 32
     prefix = "0x"
 
@@ -39,7 +39,7 @@ class Hash32(FixedBytes):
         return self.prefix + self.hex()
 
 
-class Address(FixedBytes, metaclass=ABCMeta):
+class Address(Bytes, metaclass=ABCMeta):
     size = 20
 
     def hex_xx(self):
@@ -50,14 +50,15 @@ class Address(FixedBytes, metaclass=ABCMeta):
         if isinstance(value, int):
             return super().fromhex(value)
 
-        prefix = value[:2]
-        if prefix == ContractAddress.prefix:
-            return ContractAddress(bytes.fromhex(value[2:]))
+        prefix, contents = value[:2], value[2:]
+        if len(contents) == cls.size * 2:
+            if prefix == ContractAddress.prefix:
+                return ContractAddress(bytes.fromhex(contents))
 
-        if prefix == ExternalAddress.prefix:
-            return ExternalAddress(bytes.fromhex(value[2:]))
+            if prefix == ExternalAddress.prefix:
+                return ExternalAddress(bytes.fromhex(contents))
 
-        return ExternalAddress(bytes.fromhex(value))
+        return MalformedAddress(value)
 
 
 class ExternalAddress(Address):
@@ -74,7 +75,22 @@ class ContractAddress(Address):
         return self.prefix + self.hex()
 
 
-class Signature(FixedBytes):
+class MalformedAddress(str):
+    @classmethod
+    def fromhex(cls, value: str):
+        return MalformedAddress(value)
+
+    def hex(self):
+        return self
+
+    def hex_xx(self):
+        return self
+
+    def hex_hx(self):
+        return self
+
+
+class Signature(Bytes):
     size = 65
 
     def recover_id(self):

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -477,10 +477,9 @@ class BlockManager(Subscriber):
                                 block_verifier.invoke_func = self.__channel_service.genesis_invoke
                             else:
                                 block_verifier.invoke_func = self.__channel_service.score_invoke
-                            invoke_results = block_verifier.verify(block,
-                                                                   self.__blockchain.last_block,
-                                                                   self.__blockchain)
-
+                            invoke_results = block_verifier.verify_loosely(block,
+                                                                           self.__blockchain.last_block,
+                                                                           self.__blockchain)
                             self.__blockchain.set_invoke_results(block.header.hash.hex(), invoke_results)
                             result = self.add_block(block)
 

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -472,6 +472,16 @@ class BlockManager(Subscriber):
                             commit_state = block.header.commit_state
                             logging.debug(f"block_manager.py >> block_height_sync :: "
                                           f"height({block.header.height}) commit_state({commit_state})")
+                            block_verifier = BlockVerifier.new("0.1a")
+                            if block.header.height == 0:
+                                block_verifier.invoke_func = self.__channel_service.genesis_invoke
+                            else:
+                                block_verifier.invoke_func = self.__channel_service.score_invoke
+                            invoke_results = block_verifier.verify(block,
+                                                                   self.__blockchain.last_block,
+                                                                   self.__blockchain)
+
+                            self.__blockchain.set_invoke_results(block.header.hash.hex(), invoke_results)
                             result = self.add_block(block)
 
                             if result:

--- a/loopchain/utils/__init__.py
+++ b/loopchain/utils/__init__.py
@@ -264,10 +264,7 @@ def generate_url_from_params(ip=None, dns=None, port=None, version=None, use_htt
         ip = dns
         port = '443'
 
-    if version == conf.ApiVersion.v3 or version == conf.ApiVersion.node:
-        url = f"{'https' if use_https else 'http'}://{ip}:{port}/api/{version.name}/{channel}"
-    else:
-        url = f"{'https' if use_https else 'http'}://{ip}:{port}/api/{version.name}"
+    url = f"{'https' if use_https else 'http'}://{ip}:{port}/api/{version.name}"
 
     return url
 


### PR DESCRIPTION
Block Versioning System integration - Release (1.23.0) bug fix
- Deploy Tx generation hash and verification hash mismatch - HashGenerator version setting error during block validation
- V2 To Address error - Unmatched address - MalformedAddress type created and handled as str (no byte processing)
- V2 Nonce value format error - Unmatched format such as "0x1", "64545" - Process with str
- V2 Value Format Error - Hexadecimal number without "0x" - For v2, all processing with str (fee included)
- V2 Extra value format error - no relevant object such as "lang" exists in params
- V3 Data value format error - Hexadecimal number without "0x" despite "DataType" being "message" - All processing with str
- Modify Citizen to receive ConfirmedBlock from mainnet and test net without websocket