### PR TITLE
Fix multiple leader problem when peers try to connect at a same time

### DIFF
--- a/loopchain/radiostation/rs_outer_service.py
+++ b/loopchain/radiostation/rs_outer_service.py
@@ -255,13 +255,13 @@ class OuterService(loopchain_pb2_grpc.RadioStationServicer):
                 ObjectManager().rs_service.channel_manager.\
                     set_peer_manager(channel_name, peer_manager)
 
-        util.logger.spam(f"after load peer_manager "
-                         f"peer_count({peer_manager.get_peer_count()})")
+            util.logger.spam(f"after load peer_manager "
+                            f"peer_count({peer_manager.get_peer_count()})")
 
-        peer_order = peer_manager.add_peer(peer)
+            peer_order = peer_manager.add_peer(peer)
 
-        peer_list_dump = b''
-        status, reason = message_code.get_response(message_code.Response.fail)
+            peer_list_dump = b''
+            status, reason = message_code.get_response(message_code.Response.fail)
 
         if peer_order > 0:
             try:

--- a/loopchain/radiostation/rs_service.py
+++ b/loopchain/radiostation/rs_service.py
@@ -18,6 +18,7 @@ import multiprocessing
 import random
 import signal
 import timeit
+import time
 
 import loopchain.utils as util
 from loopchain import configure as conf
@@ -170,6 +171,10 @@ class RadioStationService:
         stopwatch_start = timeit.default_timer()
 
         self.__channel_manager = ChannelManager(self.__common_service)
+    
+        # TODO: Currently, some environments are failing to execute RestServiceRS without this sleep.
+        # This sleep fixes current node's issue but we need to fix it right way by investigating.
+        time.sleep(1)
 
         if conf.ENABLE_REST_SERVICE:
             self.__rest_service = RestServiceRS(int(port))


### PR DESCRIPTION
# Bug

This patch fixes two initial run problems.

1. In some environments, `RestServiceRS` will not run when we execute `loop rs`. The `time.sleep (1)` fixes this situation, but I added a TODO comment to encourage you to determine the exact cause.

2. Fixed an issue that occurs when multiple peers attempt to connect to the initialized loopchain at the same time. `__load_peer_manager_lock` locks total process of creating `PeerManager` and new peer information.