### PR TITLE
[DO_NOT_MERGE] Add Peer list management in each Peer.

### DIFF
--- a/loopchain/baseservice/peer_object.py
+++ b/loopchain/baseservice/peer_object.py
@@ -29,6 +29,27 @@ class PeerStatus(IntEnum):
     disconnected = 2
 
 
+class PriorPeerInfo:
+    """PriorPeerInfo is prior peer info to get peer deatils. Get PriorPeerInfo from icon service"""
+
+    def __init__(self, peer_id: str, leader_order: int, url: str):
+        self._peer_id = peer_id
+        self._leader_order = leader_order
+        self._url = url
+
+    @property
+    def peer_id(self) -> str:
+        return self._peer_id
+
+    @property
+    def leader_order(self) -> int:
+        return self._leader_order
+
+    @property
+    def url(self) -> str:
+        return self._url
+
+
 class PeerInfo:
     """Peer Object"""
 

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -449,16 +449,7 @@ class ChannelService:
             return
 
         if response and response.status == message_code.Response.success:
-            peer_list_data = pickle.loads(response.peer_list)
-            self.__peer_manager.load(peer_list_data, False)
-            peers, peer_list = self.__peer_manager.get_peers_for_debug()
-            logging.debug("peer list update: " + peers)
-
-            # add connected peer to processes audience
-            for each_peer in peer_list:
-                util.logger.spam(f"peer_service:connect_to_radio_station peer({each_peer.target}-{each_peer.status})")
-                if each_peer.status == PeerStatus.connected:
-                    self.__broadcast_scheduler.schedule_job(BroadcastCommand.SUBSCRIBE, each_peer.target)
+            self.__peer_manager.reset_peer_list()
 
     async def subscribe_to_radio_station(self):
         await self.__subscribe_call_to_stub(self.__radio_station_stub, loopchain_pb2.PEER)

--- a/loopchain/peer/peer_inner_service.py
+++ b/loopchain/peer/peer_inner_service.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import base64
+
 from typing import TYPE_CHECKING
 from earlgrey import *
 
@@ -41,6 +43,14 @@ class PeerInnerTask:
             self._peer_service.peer_port, self._peer_service.peer_target, self._peer_service.rest_target, \
             self._peer_service.radio_station_target, self._peer_service.peer_id, self._peer_service.group_id, \
             self._peer_service.node_type.value, channels_info[channel_name]['score_package']
+
+    @message_queue_task
+    async def get_peer_info(self):
+        return {
+            'peer_id': self._peer_service.peer_id,
+            'peer_target': self._peer_service.peer_target,
+            'peer_cert': base64.b64encode(self._peer_service.peer_cert)
+        }
 
     @message_queue_task
     async def stop_outer(self):

--- a/loopchain/peer/peer_service.py
+++ b/loopchain/peer/peer_service.py
@@ -91,6 +91,7 @@ class PeerService:
         self.__rest_target = None
         self.__inner_target = None
         self.__peer_port = 0
+        self.__peer_cert = None
 
         # gRPC service for Peer
         self.__inner_service: PeerInnerService = None
@@ -165,6 +166,10 @@ class PeerService:
         return self.__peer_id
 
     @property
+    def peer_cert(self):
+        return self.__peer_cert
+
+    @property
     def group_id(self):
         if self.__group_id is None:
             self.__group_id = self.__peer_id
@@ -236,7 +241,9 @@ class PeerService:
         """네트워크에서 Peer 를 식별하기 위한 UUID를 level db 에 생성한다.
         """
         if util.channel_use_icx(conf.LOOPCHAIN_DEFAULT_CHANNEL):
-            self.__peer_id = IcxAuthorization(conf.LOOPCHAIN_DEFAULT_CHANNEL).address
+            auth = IcxAuthorization(conf.LOOPCHAIN_DEFAULT_CHANNEL)
+            self.__peer_id = auth.address
+            self.__peer_cert = auth.peer_cert
         else:
             try:
                 uuid_bytes = bytes(self.__level_db.Get(conf.LEVEL_DB_KEY_FOR_PEER_ID))

--- a/loopchain/scoreservice/icon_inner_service.py
+++ b/loopchain/scoreservice/icon_inner_service.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from earlgrey import message_queue_task, MessageQueueService, MessageQueueStub
+from typing import Any
 from loopchain import utils
 
 
@@ -30,7 +31,7 @@ class IconScoreInnerTask:
         pass
 
     @message_queue_task
-    async def query(self, request: dict) -> dict:
+    async def query(self, request: dict) -> Any:
         pass
 
     @message_queue_task


### PR DESCRIPTION
- Each peer manages peer list without Radio Station.
- Gets peer list from Icon Service with query() function.
```
[
    {'peer_id': "xxxxxxxx", 'url': "http://xxx:9000"},
    ...
]
```
- Gets peer details at the URL.


TODO:

- Implements Peer list management according to leader round policy.
- Implements retrying to get peer details if it has been failed.