### PR TITLE
Change BlockSyncReply.block to optional

### DIFF
--- a/loopchain/protos/loopchain.proto
+++ b/loopchain/protos/loopchain.proto
@@ -240,7 +240,7 @@ message BlockSyncReply {
     required int32 response_code = 1;
     required int32 block_height = 2;
     required int32 max_block_height = 3;
-    required bytes block = 4;
+    optional bytes block = 4;
 }
 
 message PrecommitBlockRequest {


### PR DESCRIPTION
In `loopchain.proto`, `BlockSyncReply` message defines [`block` field as required](https://github.com/icon-project/loopchain/blob/master/loopchain/protos/loopchain.proto#L243), but when throwing the BlockSyncReply, [an optional situation](https://github.com/icon-project/loopchain/blob/cf7408dc701cb5d9607bf55ce7f7a07a45fa5cc7/loopchain/channel/channel_inner_service.py#L382) exists.

At present, it is presumed that the definition of the protobuf is incorrect and this patch changes the field to optional.