### PR TITLE
[LC-167] fixed to customize log level

### DIFF
--- a/loopchain/configure_default.py
+++ b/loopchain/configure_default.py
@@ -48,6 +48,7 @@ class LogOutputType(IntFlag):
 
 
 LOOPCHAIN_LOG_LEVEL = os.getenv('LOOPCHAIN_LOG_LEVEL', 'DEBUG')
+LOOPCHAIN_DEVELOP_LOG_LEVEL = "SPAM"
 LOOPCHAIN_OTHER_LOG_LEVEL = "WARNING"
 LOG_FORMAT = "%(asctime)s,%(msecs)03d %(process)d %(thread)d {PEER_ID} {CHANNEL_NAME}{SCORE_PACKAGE} " \
              "%(levelname)s %(filename)s(%(lineno)d) %(message)s"

--- a/loopchain/launcher.py
+++ b/loopchain/launcher.py
@@ -118,28 +118,22 @@ def start_as_rest_server(args):
     from iconrpcserver.default_conf.icon_rpcserver_config import default_rpcserver_config
     from iconrpcserver.icon_rpcserver_cli import start_process, find_procs_by_params
     from iconcommons.icon_config import IconConfig
-    from iconcommons.logger import Logger
-
-    with open(conf_path) as file:
-        load_conf = json.load(file)
 
     additional_conf = {
-        "log": load_conf.get("log"),
+        "config": conf_path,
         "channel": channel,
         "port": api_port,
         "amqpKey": amqp_key,
-        "gunicornWorkerCount": 1,
         "tbearsMode": False
     }
 
     rpcserver_conf = IconConfig("", default_rpcserver_config)
     rpcserver_conf.load()
     rpcserver_conf.update_conf(additional_conf)
-    Logger.load_config(rpcserver_conf)
 
     if not find_procs_by_params(api_port):
         start_process(conf=rpcserver_conf)
-        Logger.info("start_command done!, IconRpcServerCli")
+        logging.info("start_command done!, IconRpcServerCli")
 
 
 def start_as_rest_server_rs(args):

--- a/loopchain/utils/loggers/configuration_presets.py
+++ b/loopchain/utils/loggers/configuration_presets.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import verboselogs
 
 from enum import Enum
 from loopchain import configure as conf
@@ -72,7 +71,7 @@ def update_preset(update_logger=True):
     preset.log_monitor_port = conf.MONITOR_LOG_PORT
 
     if preset is develop:
-        preset.log_level = verboselogs.SPAM
+        preset.log_level = conf.LOOPCHAIN_DEVELOP_LOG_LEVEL
     else:
         preset.log_level = conf.LOOPCHAIN_LOG_LEVEL
 


### PR DESCRIPTION
 - When run peer for develop, rpcserver config(iconrcpserver_conf.json) is not applied,
   and rpcserver print info log by default config.
   Now fixed to apply rpcserver config properly.
 - add develop log level in configuration by SPAM and customize in test_x_conf.json