### PR TITLE
[LC-183] Fix invoke results memory leak

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -255,7 +255,7 @@ class BlockChain:
                                 f"channel_service.score_write_precommit_state")
                 raise e
             finally:
-                self.__invoke_results.pop(block.header.hash, None)
+                self.__invoke_results.pop(block.header.hash.hex(), None)
 
             next_total_tx = self.__write_block_data(block, block_info)
 


### PR DESCRIPTION
- Add a invoke result into map, use block.hash.hex() as key.
- Pop a invoke result from map, use block.hash as key.