### PR TITLE
[LC-184] Fix candidate block memory leak while BlockGenerator don't change

### DIFF
--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -19,7 +19,7 @@ from functools import partial
 import loopchain.utils as util
 from loopchain import configure as conf
 from loopchain.baseservice import ObjectManager, TimerService, SlotTimer, Timer
-from loopchain.blockchain import ExternalAddress, BlockVerifier, Hash32, Vote
+from loopchain.blockchain import ExternalAddress, BlockVerifier, Hash32, Vote, Block
 from loopchain.channel.channel_property import ChannelProperty
 from loopchain.peer.consensus_base import ConsensusBase
 
@@ -76,8 +76,7 @@ class ConsensusSiever(ConsensusBase):
                         if not vote_result:
                             return self.__block_generation_timer.call()
 
-                        self._block_manager.get_blockchain().add_block(last_unconfirmed_block, vote)
-                        self._made_block_count += 1
+                        self.__add_block(last_unconfirmed_block, vote)
 
                         next_leader = last_unconfirmed_block.header.next_leader
             else:
@@ -92,8 +91,7 @@ class ConsensusSiever(ConsensusBase):
                     if not vote_result:
                         return self.__block_generation_timer.call()
 
-                    self._block_manager.get_blockchain().add_block(last_unconfirmed_block, vote)
-                    self._made_block_count += 1
+                    self.__add_block(last_unconfirmed_block, vote)
 
                     peer_manager = ObjectManager().channel_service.peer_manager
                     next_leader = ExternalAddress.fromhex(peer_manager.get_next_leader_peer(
@@ -163,6 +161,11 @@ class ConsensusSiever(ConsensusBase):
     #             logging.warning("Timed Out Block not confirmed duration: " +
     #                             str(util.diff_in_seconds(candidate_block.header.timestamp)))
     #             return False
+
+    def __add_block(self, block: Block, vote: Vote):
+        self._block_manager.get_blockchain().add_block(block, vote)
+        self._block_manager.candidate_blocks.remove_block(block.header.hash)
+        self._made_block_count += 1
 
     @staticmethod
     def __start_broadcast_send_unconfirmed_block_timer(broadcast_func):


### PR DESCRIPTION
- Current version don't change BlockGenerator while sending transaction continuously
- REP remove candidate block when REP receive AnnounceUnconfirmedBlock
- BlockGenerator don't receive AnnounceUnconfirmedBlock (BlockGenerator just send)
- If BlockGenerator don't change, BlockGenerator never remove candidate block.
- But normally, BlockGenerator may be changed, candidate block may be removed after 60 minute.