### PR TITLE
[LC-175] Fix some bugs is related to synchronization of block height.

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -671,7 +671,7 @@ class BlockChain:
 
             return unconfirmed_block
 
-    def init_blockchain(self, is_leader=False):
+    def init_blockchain(self):
         # level DB에서 블럭을 읽어 들이며, 만약 levelDB에 블럭이 없을 경우 제네시스 블럭을 만든다
         try:
             last_block_key = self.__confirmed_block_db.Get(BlockChain.LAST_BLOCK_KEY, True)

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -597,12 +597,10 @@ class ChannelService:
         peer_type = loopchain_pb2.PEER
         self.__ready_to_height_sync()
         blockchain = self.block_manager.get_blockchain()
-
-        if blockchain.last_unconfirmed_block:
-            leader_id = blockchain.last_unconfirmed_block.header.next_leader.hex_hx()
-            self.peer_manager.set_leader_peer(self.peer_manager.get_peer(leader_id))
-        elif blockchain.last_block:
-            leader_id = blockchain.last_block.header.next_leader.hex_hx()
+        last_block = blockchain.last_unconfirmed_block or blockchain.last_block
+        
+        if last_block:
+            leader_id = last_block.header.next_leader.hex_hx()
             self.peer_manager.set_leader_peer(self.peer_manager.get_peer(leader_id))
         else:
             leader_id = self.peer_manager.get_leader_peer().peer_id

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -493,6 +493,7 @@ class BlockManager:
         if target_height is not None:
             max_height = target_height
 
+        self.__blockchain.last_unconfirmed_block = None
         my_height = self.__current_block_height()
         retry_number = 0
         util.logger.spam(f"block_manager:block_height_sync my_height({my_height})")

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -580,6 +580,7 @@ class BlockManager:
 
         if my_height >= max_height:
             util.logger.debug(f"block_manager:block_height_sync is complete.")
+            self.__unconfirmedBlockQueue = queue.Queue()
             self.epoch.set_epoch_leader(self.__channel_service.peer_manager.get_leader_id(conf.ALL_GROUP_ID))
             self.__channel_service.state_machine.subscribe_network()
         else:


### PR DESCRIPTION
There are some problems to synchronize of block height.
 - Couldn't be complete perfectly to synchronize of block height.
 - Couldn't synchronize of block height when there are different on the same height between last unconfirmed block of a node and the block of the same height with that of leader.
 - Set the first node to the leader always when all restarts.

That's why I fixed them like this:
- Reset unconfirmed block queue after block height synchronization.
- Set the leader, which is the next leader of a block(the last block or a last unconfirmed block).
- Set None to `last_unconfirmed_block` before figure `my_height`out in logic to synchronize height of block.