### PR TITLE
[LC-225] Ignore some broadcast for unconfirmed block

### DIFF
--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -81,7 +81,7 @@ class ChannelStateMachine(object):
     def subscribe_network(self):
         pass
 
-    @statemachine.transition(source='Vote', dest='Vote', after='_do_vote')
+    @statemachine.transition(source=('Vote', 'LeaderComplain'), dest='Vote', after='_do_vote')
     def vote(self):
         pass
 

--- a/loopchain/peer/peer_outer_service.py
+++ b/loopchain/peer/peer_outer_service.py
@@ -542,7 +542,7 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
                      f"request height({request.block_height}) channel({channel_name})")
 
         channel_stub = StubCollection().channel_stubs[channel_name]
-        response_code, block_height, max_block_height, confirm_info, block_dumped = \
+        response_code, block_height, max_block_height, unconfirmed_block_height, confirm_info, block_dumped = \
             channel_stub.sync_task().block_sync(request.block_hash, request.block_height)
 
         return loopchain_pb2.BlockSyncReply(
@@ -550,7 +550,8 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
             block_height=block_height,
             max_block_height=max_block_height,
             confirm_info=bytes(confirm_info) if confirm_info else b"",
-            block=block_dumped)
+            block=block_dumped,
+            unconfirmed_block_height=unconfirmed_block_height)
 
     def Subscribe(self, request, context):
         """BlockGenerator 가 broadcast(unconfirmed or confirmed block) 하는 채널에

--- a/loopchain/protos/loopchain.proto
+++ b/loopchain/protos/loopchain.proto
@@ -243,6 +243,7 @@ message BlockSyncReply {
     required int32 max_block_height = 3;
     optional bytes confirm_info = 4;
     optional bytes block = 5;
+    required int32 unconfirmed_block_height = 6;
 }
 
 message PrecommitBlockRequest {


### PR DESCRIPTION
Sometimes, Peer receive some unconfirmed block broadcast
for block that is already confirmed.