### PR TITLE
[LC-237] Add logic to reset leader after leader complain.

### DIFF
--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -824,6 +824,7 @@ class ChannelInnerTask:
                 self._channel_service.state_machine.turn_to_peer()
             block_manager.epoch.prev_leader_id = next_new_leader
             self._channel_service.reset_leader_complain_timer()
+            self._channel_service.reset_leader(next_new_leader)
 
     @message_queue_task
     def get_invoke_result(self, tx_hash):


### PR DESCRIPTION
There are some difference of leader info between `peer_list` in peer_manager.py and `epoch` in block_manager.py.
It means there are some difference to set the leader between leader complaint logic and leader rotation logic.
I fix it to use the same method for resetting leader to case both of them.