### PR TITLE
[LC-243] bug fix when add_confirmed_block error in citizen node

### DIFF
--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -75,7 +75,7 @@ class ChannelStateMachine(object):
     def block_sync(self):
         pass
 
-    @statemachine.transition(source=('BlockSync', 'EvaluateNetwork', 'Watch'),
+    @statemachine.transition(source=('BlockSync', 'EvaluateNetwork'),
                              dest='SubscribeNetwork',
                              after='_do_subscribe_network')
     def subscribe_network(self):
@@ -163,5 +163,3 @@ class ChannelStateMachine(object):
 
     def _leadercomplain_on_exit(self):
         util.logger.debug(f"_leadercomplain_on_exit")
-
-    # }

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -75,9 +75,7 @@ class ChannelStateMachine(object):
     def block_sync(self):
         pass
 
-    @statemachine.transition(source=('BlockSync', 'EvaluateNetwork'),
-                             dest='SubscribeNetwork',
-                             after='_do_subscribe_network')
+    @statemachine.transition(source='BlockSync', dest='SubscribeNetwork', after='_do_subscribe_network')
     def subscribe_network(self):
         pass
 

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -280,9 +280,13 @@ class BlockManager:
         return True
 
     def add_confirmed_block(self, confirmed_block: Block):
-        result = self.__blockchain.add_block(confirmed_block)
-        if not result:
-            self.block_height_sync()
+        my_height = self.__blockchain.last_block.header.height
+        if confirmed_block.header.height == my_height + 1:
+            result = self.__blockchain.add_block(confirmed_block)
+            if result:
+                return
+
+        self.block_height_sync()
 
     def rebuild_block(self):
         self.__blockchain.rebuild_transaction_count()

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -638,7 +638,10 @@ class BlockManager:
             rest_stub = ObjectManager().channel_service.radio_station_stub
             peer_stubs.append(rest_stub)
             response = rest_stub.call("Status")
-            max_height = int(json.loads(response.text)["block_height"])
+            height_from_status = int(json.loads(response.text)["block_height"])
+            last_height = rest_stub.call("GetLastBlock").get('height')
+            logging.debug(f"last_height: {last_height}, height_from_status: {height_from_status}")
+            max_height = max(height_from_status, last_height)
             unconfirmed_block_height = int(
                 json.loads(response.text).get("unconfirmed_block_height", -1)
             )

--- a/loopchain/utils/loggers/configuration.py
+++ b/loopchain/utils/loggers/configuration.py
@@ -181,7 +181,7 @@ class LogConfiguration:
             if not os.path.isdir(self.log_file_location):
                 raise RuntimeError(f"LogFileLocation({self.log_file_location}) is not a directory.")
         else:
-            os.makedirs(self.log_file_location)
+            os.makedirs(self.log_file_location, exist_ok=True)
 
         if self.log_file_rotate_when and self.log_file_rotate_max_bytes:
             file_handler = SizedTimedRotatingFileHandler(

--- a/testcase/unittest/test_channel_statemachine.py
+++ b/testcase/unittest/test_channel_statemachine.py
@@ -39,6 +39,12 @@ class MockBlockManager:
     def block_height_sync(self):
         pass
 
+    def stop_block_height_sync_timer(self):
+        pass
+
+    def update_service_status(self, status):
+        pass
+
 
 class MockBlockManagerCitizen:
     peer_type = loopchain_pb2.PEER
@@ -47,6 +53,12 @@ class MockBlockManagerCitizen:
         pass
 
     def block_height_sync(self):
+        pass
+
+    def stop_block_height_sync_timer(self):
+        pass
+
+    def update_service_status(self, status):
         pass
 
 
@@ -118,12 +130,13 @@ class TestChannelStateMachine(unittest.TestCase):
         util.logger.spam(f"\nstate is {channel_state_machine.state}")
 
         # THEN
-        self.assertEqual(channel_state_machine.state, "EvaluateNetwork")
+        self.assertEqual("EvaluateNetwork", channel_state_machine.state)
 
     def test_change_state_by_condition(self):
         # GIVEN
         channel_state_machine = ChannelStateMachine(MockChannelService())
         channel_state_machine.complete_init_components()
+        channel_state_machine.block_sync()
         channel_state_machine.subscribe_network()
         util.logger.spam(f"\nstate is {channel_state_machine.state}")
 
@@ -132,12 +145,13 @@ class TestChannelStateMachine(unittest.TestCase):
         util.logger.spam(f"\nstate is {channel_state_machine.state}")
 
         # THEN
-        self.assertEqual(channel_state_machine.state, "BlockGenerate")
+        self.assertEqual("BlockGenerate", channel_state_machine.state)
 
     def test_change_state_by_multiple_condition(self):
         # GIVEN
         channel_state_machine = ChannelStateMachine(MockChannelServiceCitizen())
         channel_state_machine.complete_init_components()
+        channel_state_machine.block_sync()
         channel_state_machine.subscribe_network()
         util.logger.spam(f"\nstate is {channel_state_machine.state}")
 
@@ -146,13 +160,14 @@ class TestChannelStateMachine(unittest.TestCase):
         util.logger.spam(f"\nstate is {channel_state_machine.state}")
 
         # THEN
-        self.assertEqual(channel_state_machine.state, "Watch")
+        self.assertEqual("Watch", channel_state_machine.state)
 
     def test_change_state_from_same_state(self):
         # GIVEN
         mock_channel_service = MockChannelService()
         channel_state_machine = ChannelStateMachine(mock_channel_service)
         channel_state_machine.complete_init_components()
+        channel_state_machine.block_sync()
         channel_state_machine.subscribe_network()
         channel_state_machine.complete_subscribe()
         util.logger.spam(f"\nstate is {channel_state_machine.state}")
@@ -164,7 +179,7 @@ class TestChannelStateMachine(unittest.TestCase):
         util.logger.spam(f"\nstate is {channel_state_machine.state}")
 
         # THEN
-        self.assertEqual(mock_channel_service.block_manager.timer_called, 1)
+        self.assertEqual(1, mock_channel_service.block_manager.timer_called)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- restrict add_confirmed_block only when the height difference is 1.
- prevent switching from state 'Watch' to state 'Subscribe'
- update max_height in block_sync since 'get_status' api doesn't guarantee the real-time last block height.