### PR TITLE
[LC-270] refactoring announce_unconfirmed_block to verify block_info when confirm prev block.

### DIFF
--- a/loopchain/blockchain/exception.py
+++ b/loopchain/blockchain/exception.py
@@ -35,6 +35,12 @@ class BlockchainError(Exception):
     pass
 
 
+class AddUnconfirmedBlock(Exception):
+    """
+    """
+    pass
+
+
 class BlockVersionNotMatch(Exception):
     def __init__(self, block_version: str, target_version: str, msg: str):
         super().__init__(msg)

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -660,7 +660,7 @@ class ChannelInnerTask:
         if not added:
             return
 
-        self._channel_service.state_machine.vote()
+        self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block)
 
         if self._channel_service.peer_manager.get_leader_id(conf.ALL_GROUP_ID) != \
                 unconfirmed_block.header.next_leader.hex_hx():

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -656,18 +656,7 @@ class ChannelInnerTask:
             util.logger.debug(f"Can't add unconfirmed block in state({self._channel_service.state_machine.state}).")
             return
 
-        added = self._channel_service.block_manager.add_unconfirmed_block(unconfirmed_block)
-        if not added:
-            return
-
         self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block)
-
-        if self._channel_service.peer_manager.get_leader_id(conf.ALL_GROUP_ID) != \
-                unconfirmed_block.header.next_leader.hex_hx():
-            util.logger.debug(f"reset leader to ({unconfirmed_block.header.next_leader.hex_hx()})")
-            await self._channel_service.reset_leader(unconfirmed_block.header.next_leader.hex_hx())
-
-        self._channel_service.start_leader_complain_timer_if_tx_exists()
 
     @message_queue_task
     async def announce_confirmed_block(self, serialized_block, commit_state="{}"):

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -610,6 +610,16 @@ class ChannelService:
             logging.debug("peer_target: " + peer)
 
     async def reset_leader(self, new_leader_id, block_height=0, complained=False):
+        """
+
+        :param new_leader_id:
+        :param block_height:
+        :param complained:
+        :return:
+        """
+        if self.peer_manager.get_leader_id(conf.ALL_GROUP_ID) == new_leader_id:
+            return
+
         utils.logger.info(f"RESET LEADER channel({ChannelProperty().name}) leader_id({new_leader_id}), "
                           f"complained={complained}")
         leader_peer = self.peer_manager.get_peer(new_leader_id, None)

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -122,7 +122,7 @@ class ChannelStateMachine(object):
 
     def _do_vote(self, unconfirmed_block: Block):
         util.logger.notice(f"in _do_vote unconfirmed_block({unconfirmed_block})")
-        self.__channel_service.block_manager.vote_as_peer(unconfirmed_block)
+        self._run_coroutine_threadsafe(self.__channel_service.block_manager.vote_as_peer(unconfirmed_block))
 
     def _consensus_on_enter(self):
         self.block_height_sync()

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -121,27 +121,26 @@ class ChannelStateMachine(object):
         self._run_coroutine_threadsafe(self.__channel_service.subscribe_network())
 
     def _do_vote(self, unconfirmed_block: Block):
-        util.logger.notice(f"in _do_vote unconfirmed_block({unconfirmed_block})")
         self._run_coroutine_threadsafe(self.__channel_service.block_manager.vote_as_peer(unconfirmed_block))
 
-    def _consensus_on_enter(self):
+    def _consensus_on_enter(self, *args, **kwargs):
         self.block_height_sync()
 
-    def _blockheightsync_on_enter(self):
+    def _blockheightsync_on_enter(self, *args, **kwargs):
         self.evaluate_network()
 
-    def _blocksync_on_enter(self):
+    def _blocksync_on_enter(self, *args, **kwargs):
         self.__channel_service.block_manager.update_service_status(status_code.Service.block_height_sync)
 
-    def _blocksync_on_exit(self):
+    def _blocksync_on_exit(self, *args, **kwargs):
         self.__channel_service.block_manager.stop_block_height_sync_timer()
         self.__channel_service.block_manager.update_service_status(status_code.Service.online)
 
-    def _subscribe_network_on_enter(self):
+    def _subscribe_network_on_enter(self, *args, **kwargs):
         self.__channel_service.start_subscribe_timer()
         self.__channel_service.start_shutdown_timer()
 
-    def _subscribe_network_on_exit(self):
+    def _subscribe_network_on_exit(self, *args, **kwargs):
         self.__channel_service.stop_subscribe_timer()
         self.__channel_service.stop_shutdown_timer()
 
@@ -152,19 +151,19 @@ class ChannelStateMachine(object):
     def _vote_on_exit(self, *args, **kwargs):
         pass
 
-    def _blockgenerate_on_enter(self):
+    def _blockgenerate_on_enter(self, *args, **kwargs):
         loggers.get_preset().is_leader = True
         loggers.get_preset().update_logger()
         self.__channel_service.block_manager.start_block_generate_timer()
 
-    def _blockgenerate_on_exit(self):
+    def _blockgenerate_on_exit(self, *args, **kwargs):
         self.__channel_service.block_manager.stop_block_generate_timer()
 
-    def _leadercomplain_on_enter(self):
+    def _leadercomplain_on_enter(self, *args, **kwargs):
         util.logger.debug(f"_leadercomplain_on_enter")
         self.__channel_service.block_manager.leader_complain()
 
-    def _leadercomplain_on_exit(self):
+    def _leadercomplain_on_exit(self, *args, **kwargs):
         util.logger.debug(f"_leadercomplain_on_exit")
 
     def _run_coroutine_threadsafe(self, coro):

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """State Machine for Channel Service"""
+
 import asyncio
 import traceback
 
@@ -20,6 +21,7 @@ from transitions import State
 
 import loopchain.utils as util
 from loopchain import configure as conf
+from loopchain.blockchain import Block
 from loopchain.peer import status_code
 from loopchain.protos import loopchain_pb2
 from loopchain.statemachine import statemachine
@@ -118,8 +120,9 @@ class ChannelStateMachine(object):
     def _do_subscribe_network(self):
         self._run_coroutine_threadsafe(self.__channel_service.subscribe_network())
 
-    def _do_vote(self):
-        self.__channel_service.block_manager.vote_as_peer()
+    def _do_vote(self, unconfirmed_block: Block):
+        util.logger.notice(f"in _do_vote unconfirmed_block({unconfirmed_block})")
+        self.__channel_service.block_manager.vote_as_peer(unconfirmed_block)
 
     def _consensus_on_enter(self):
         self.block_height_sync()
@@ -142,12 +145,11 @@ class ChannelStateMachine(object):
         self.__channel_service.stop_subscribe_timer()
         self.__channel_service.stop_shutdown_timer()
 
-    def _vote_on_enter(self):
+    def _vote_on_enter(self, *args, **kwargs):
         loggers.get_preset().is_leader = False
         loggers.get_preset().update_logger()
 
-    def _vote_on_exit(self):
-        # util.logger.debug(f"_vote_on_exit")
+    def _vote_on_exit(self, *args, **kwargs):
         pass
 
     def _blockgenerate_on_enter(self):

--- a/loopchain/configure_default.py
+++ b/loopchain/configure_default.py
@@ -446,5 +446,5 @@ CONF_PATH_ICONSERVICE_MAINNET = os.path.join(LOOPCHAIN_ROOT_PATH, 'conf/mainnet/
 CONF_PATH_ICONRPCSERVER_DEV = os.path.join(LOOPCHAIN_ROOT_PATH, 'conf/develop/iconrpcserver_conf.json')
 CONF_PATH_ICONRPCSERVER_TESTNET = os.path.join(LOOPCHAIN_ROOT_PATH, 'conf/testnet/iconrpcserver_conf.json')
 CONF_PATH_ICONRPCSERVER_MAINNET = os.path.join(LOOPCHAIN_ROOT_PATH, 'conf/mainnet/iconrpcserver_conf.json')
-TIMEOUT_FOR_LEADER_COMPLAIN = 20
+TIMEOUT_FOR_LEADER_COMPLAIN = 60
 MAX_TIMEOUT_FOR_LEADER_COMPLAIN = 300

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -741,7 +741,7 @@ class BlockManager:
         )
         self.__channel_service.broadcast_scheduler.schedule_broadcast("VoteUnconfirmedBlock", block_vote)
 
-    def vote_as_peer(self):
+    def vote_as_peer(self, unconfirmed_block: Block):
         """Vote to AnnounceUnconfirmedBlock
         """
         if self.__unconfirmedBlockQueue.empty():

--- a/loopchain/utils/loggers/configuration_presets.py
+++ b/loopchain/utils/loggers/configuration_presets.py
@@ -86,7 +86,7 @@ def update_preset(update_logger=True):
     preset.log_monitor_port = conf.MONITOR_LOG_PORT
 
     if preset is develop:
-        preset.log_level = conf.LOOPCHAIN_DEVELOP_LOG_LEVEL
+        preset.log_level = "NOTICE"  # conf.LOOPCHAIN_DEVELOP_LOG_LEVEL
     else:
         preset.log_level = conf.LOOPCHAIN_LOG_LEVEL
 

--- a/loopchain/utils/loggers/configuration_presets.py
+++ b/loopchain/utils/loggers/configuration_presets.py
@@ -86,7 +86,7 @@ def update_preset(update_logger=True):
     preset.log_monitor_port = conf.MONITOR_LOG_PORT
 
     if preset is develop:
-        preset.log_level = "NOTICE"  # conf.LOOPCHAIN_DEVELOP_LOG_LEVEL
+        preset.log_level = conf.LOOPCHAIN_DEVELOP_LOG_LEVEL
     else:
         preset.log_level = conf.LOOPCHAIN_LOG_LEVEL
 


### PR DESCRIPTION
* Call state machine trigger 'vote' with unconfirmed block param.

* remove __unconfirmedBlockQueue

* Send failed vote when AddUnconfirmedBlock exception raised.

* set TIMEOUT_FOR_LEADER_COMPLAIN to 60 (1 min.)