### PR TITLE
[LC-296] Ignore unconfirmed block that has already been received from complained leader.

### DIFF
--- a/loopchain/blockchain/exception.py
+++ b/loopchain/blockchain/exception.py
@@ -35,7 +35,13 @@ class BlockchainError(Exception):
     pass
 
 
-class AddUnconfirmedBlock(Exception):
+class InvalidUnconfirmedBlock(Exception):
+    """
+    """
+    pass
+
+
+class DuplicationUnconfirmedBlock(Exception):
     """
     """
     pass


### PR DESCRIPTION
When Rep. receive an unconfirmed block that is already received, Rep. just need to vote for the block.