### PR TITLE
[LC-310] upgrade websockets support python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,11 +17,13 @@ pika==0.12.0
 python-pkcs11==0.5.0
 requests==2.20.0
 cryptography==2.3.1
-sanic==0.8.3
+sanic==18.12.0; python_version >= '3.7'
+sanic==0.8.3; python_version < '3.7'
 secp256k1==0.13.2
 setproctitle==1.1.10
 transitions==0.6.8
 verboselogs==1.7
-websockets==5.0.1
+websockets==6.0; python_version >= '3.7'
+websockets==5.0.1; python_version < '3.7'
 yappi==0.98
 dataclasses; python_version < '3.7'


### PR DESCRIPTION
 - websockets 6.0 required in python 3.7