### PR TITLE
[LC-312] Add switching role between P-Rep and Citizen

### DIFF
--- a/docs/8. diagram/state_machine_in_siever.wsd
+++ b/docs/8. diagram/state_machine_in_siever.wsd
@@ -1,31 +1,39 @@
 @startuml State Machine in Siever
-
 [*] --> InitComponents
-InitComponents: ChannelService init
 
-InitComponents --> Consensus : trigger::complete_init_components
+state InitComponents {
+    InitComponents: ChannelService init
+}
 
-state Timer
-Timer: * Connect to Radiostation
-Timer: * heartbeat to peers
-Timer: * leader complain
-Timer: * block generate
-Timer: * Subscribe
-Timer: * Shutdown
+state Timer {
+    Timer: * Connect to Radiostation
+    Timer: * heartbeat to peers
+    Timer: * leader complain
+    Timer: * block generate
+    Timer: * Subscribe
+    Timer: * Shutdown
+}
+
+state GracefulShutdown {
+    GracefulShutdown: StopTimer: ALL
+}
 
 state Consensus {
     Consensus: on_enter { block_height_sync }
-    [*] --> BlockHeightSync : trigger::block_height_sync
 
-    state BlockHeightSync {
-        [*] --> EvaluateNetwork : trigger::evaluate_network
+    [*] -[thickness=2]-> EvaluateNetwork : trigger::evaluate_network
 
+    state EvaluateNetwork {
         EvaluateNetwork: ready to block height sync
-        EvaluateNetwork --> BlockSync : \ntrigger::block_sync
-        
-        BlockSync: Check Highest Block in Network
-        BlockSync --> SubscribeNetwork : Succeeded\ntrigger::complete_sync
+        EvaluateNetwork: select node type
+        EvaluateNetwork: initialize network
+    }
 
+    state BlockSync {
+        BlockSync: Check Highest Block in Network
+    }
+
+    state SubscribeNetwork {
         SubscribeNetwork: on_enter {
         SubscribeNetwork: \tStartTimer: Subscribe
         SubscribeNetwork: \tStartTimer: Shutdown
@@ -35,54 +43,87 @@ state Consensus {
         SubscribeNetwork: \tStopTimer: Subscribe
         SubscribeNetwork: \tStopTimer: Shutdown
         SubscribeNetwork:}
-        SubscribeNetwork -right-> [*]
     }
-    BlockHeightSync: on_enter { evaluate_network }
-    BlockHeightSync --> BlockGenerate: (if not leader)\ntrigger::complete_subscribe
-    BlockHeightSync -> Vote: (if leader)\ntrigger::complete_subscribe
-    BlockHeightSync -> Watch: (if node_type == citizen)\ntrigger::complete_subscribe
-    
-    Watch: Wait for new block announcement (subscribe_loop)
-    Watch --> BlockHeightSync: Reconnect to RS Peer\n(after connection error)\ntrigger::subscribe_network
-    Vote: on_enter {
-    Vote: }
-    Vote: on_exit {
-    Vote: }
-    Vote: 
-    Vote: trigger::vote\n(Recv AnnounceUnConfirmedBlock (block.height == mine + 1))
-    Vote -left-> BlockHeightSync : dest::BlockSync\n(block.height >= mine + 2)\ntrigger::block_sync
-    Vote -> BlockGenerate : Recv AnnounceUnConfirmedBlock\ntrigger::turn_to_leader\n(if next leader == self)
-    Vote -> LeaderComplain : !Recv heartbeat from leader by Timer (leader complain) \nSend LeaderComplain
 
-    BlockGenerate: on_enter {
-    BlockGenerate: \tAddTimer: heartbeat to peers
-    BlockGenerate: \tAddTimer: block generate (default interval = 2 sec.)
-    BlockGenerate: }
-    BlockGenerate: on_exit {
-    BlockGenerate: \tStopTimer: heartbeat to peers
-    BlockGenerate: \tStopTimer: block generate
-    BlockGenerate: }
-    BlockGenerate -> Vote : Send AnnounceConfirmedBlock\ntrigger::turn_to_peer\n(block_type == vote)
+    state Watch {
+        Watch: Wait for new block announcement (subscribe_loop)
+    }
 
-    state LeaderComplain
+    state Vote {
+        Vote: on_enter {
+        Vote: }
+        Vote: on_exit {
+        Vote: }
+        Vote:
+        Vote: trigger::vote\n(Recv AnnounceUnConfirmedBlock (block.height == mine + 1))
+    }
+
+    state BlockGenerate {
+        BlockGenerate: on_enter {
+        BlockGenerate: \tAddTimer: heartbeat to peers
+        BlockGenerate: \tAddTimer: block generate (default interval = 2 sec.)
+        BlockGenerate: }
+        BlockGenerate: on_exit {
+        BlockGenerate: \tStopTimer: heartbeat to peers
+        BlockGenerate: \tStopTimer: block generate
+        BlockGenerate: }
+    }
+
+    state LeaderComplain {
+        LeaderComplain: on_enter {
+        LeaderComplain: \tbroadcast complain
+        LeaderComplain: }
+        LeaderComplain: on_exit {
+        LeaderComplain: }
+    }
     note top of LeaderComplain
       keep leader complain Timer
       until new leader elected
       leader complain timer start by AddTx(List), and stop by AddBlock
     end note
-    LeaderComplain -> Vote : Recv AnnounceNewLeader\n(if next leader != self)
-    LeaderComplain --> BlockGenerate : Send AnnounceNewLeader\n(if next leader == self)
-    LeaderComplain: on_enter {
-    LeaderComplain: \tbroadcast complain
-    LeaderComplain: }
-    LeaderComplain: on_exit {
-    LeaderComplain: }
-    LeaderComplain: 
+
+    state ResetNetwork {
+        ResetNetwork: on_enter {
+        ResetNetwork: \tClean network
+        ResetNetwork: \tevaluate_network
+        ResetNetwork: }
+    }
 }
 
-Consensus --> GracefulShutdown
+'----- Relations
+' Enter Consensus
+InitComponents --> Consensus: trigger::complete_init_components
 
-GracefulShutdown: StopTimer: ALL
+' In BlockHeightSync
+EvaluateNetwork -[thickness=2]-> BlockSync: \ntrigger::block_sync
+BlockSync -[thickness=2]-> SubscribeNetwork: Succeeded\ntrigger::complete_sync
+SubscribeNetwork -[#green,thickness=2]-> BlockGenerate: <color:green>(if leader)\ntrigger::complete_subscribe
+SubscribeNetwork -left[#blue,thickness=2]-> Watch: <color:blue>(if node_type == citizen)\ntrigger::complete_subscribe
+SubscribeNetwork -right[#purple,thickness=2]-> Vote: <color:purple>(if not leader)\ntrigger::complete_subscribe
+
+' BlockGenerate
+Vote -down-> BlockGenerate : Recv AnnounceUnConfirmedBlock\ntrigger::turn_to_leader\n(if next leader == self)
+BlockGenerate -up-> Vote : Send AnnounceConfirmedBlock\ntrigger::turn_to_peer\n(block_type == vote)
+
+' Watch
+Watch -right-> EvaluateNetwork: Reconnect to RS Peer\n(after connection error)\ntrigger::subscribe_network
+
+' Vote
+Vote -up-> EvaluateNetwork: dest::BlockSync\n(block.height >= mine + 2)\ntrigger::block_sync
+Vote -right-> LeaderComplain : !Recv heartbeat from leader by Timer (leader complain) \nSend LeaderComplain
+LeaderComplain -left-> Vote : Recv AnnounceNewLeader\n(if next leader != self)
+LeaderComplain --> BlockGenerate : Send AnnounceNewLeader\n(if next leader == self)
+
+' Into ResetNetwork
+Watch -[dashed]-> ResetNetwork : Added a block(role_switch_block_height)\ntrigger::switch_role
+Vote -[dashed]-> ResetNetwork : Added a block(role_switch_block_height)\ntrigger::switch_role
+BlockSync -[dashed]-> ResetNetwork : Added a block(role_switch_block_height)\ntrigger::switch_role
+BlockGenerate -[dashed]-> ResetNetwork : Added a block(role_switch_block_height)\ntrigger::switch_role
+
+'ResetNetwork -> EvaluateNetwork
+
+' Exit Consensus
+Consensus --> GracefulShutdown
 GracefulShutdown --> [*]
 
 @enduml

--- a/loopchain/baseservice/timer_service.py
+++ b/loopchain/baseservice/timer_service.py
@@ -209,6 +209,9 @@ class TimerService(CommonThread):
 
         self.__loop.call_soon_threadsafe(self.__loop.stop)
 
+    def clean(self):
+        self.__timer_list = {}
+
     def run(self, e: threading.Event):
         e.set()
 

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -301,6 +301,9 @@ class BlockChain:
 
             # notify new block
             ObjectManager().channel_service.inner_service.notify_new_block()
+            # reset_network_by_block_height is called in critical section by self.__add_block_lock.
+            # Other Blocks must not be added until reset_network_by_block_height function finishes.
+            ObjectManager().channel_service.reset_network_by_block_height(self.__last_block.header.height)
 
             return True
 

--- a/loopchain/configure_default.py
+++ b/loopchain/configure_default.py
@@ -378,7 +378,8 @@ CHANNEL_OPTION = {
         "load_cert": False,
         "consensus_cert_use": False,
         "tx_cert_use": False,
-        "key_load_type": KeyLoadType.FILE_LOAD
+        "key_load_type": KeyLoadType.FILE_LOAD,
+        "role_switch_block_height": -1
     },
     LOOPCHAIN_TEST_CHANNEL: {
         "block_versions": {
@@ -392,7 +393,8 @@ CHANNEL_OPTION = {
         "load_cert": False,
         "consensus_cert_use": False,
         "tx_cert_use": False,
-        "key_load_type": KeyLoadType.FILE_LOAD
+        "key_load_type": KeyLoadType.FILE_LOAD,
+        "role_switch_block_height": -1
     }
 }
 

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -89,10 +89,12 @@ class ConsensusSiever(ConsensusBase):
 
             if complained_result:
                 util.logger.spam("consensus block_builder.complained")
+                """
                 confirm_info = self._blockchain.find_confirm_info_by_hash(self._blockchain.last_block.header.hash)
                 if not confirm_info and self._blockchain.last_block.header.height > 0:
                     util.logger.spam("Can't make a block as a leader, this peer will be complained too.")
                     return
+                """
 
                 self._made_block_count += 1
             elif len(block_builder.transactions) > 0:

--- a/loopchain/peer/peer_inner_service.py
+++ b/loopchain/peer/peer_inner_service.py
@@ -85,6 +85,9 @@ class PeerInnerTask:
 
         util.exit_and_msg(message)
 
+    @message_queue_task
+    async def change_node_type(self, node_type):
+        await self._peer_service.change_node_type(node_type)
 
 class PeerInnerService(MessageQueueService[PeerInnerTask]):
     TaskType = PeerInnerTask

--- a/loopchain/protos/message_code.py
+++ b/loopchain/protos/message_code.py
@@ -71,6 +71,7 @@ class Response:
     fail_subscribe_limit = -15
     fail_invalid_key_error = -16
     fail_wrong_block_height = -17
+    fail_no_permission = -18
     fail_tx_invalid_unknown = -100
     fail_tx_invalid_hash_format = -101
     fail_tx_invalid_hash_generation = -102
@@ -149,6 +150,9 @@ responseCodeMap = {
 
     Response.fail_wrong_block_height:
         (Response.fail_wrong_block_height, "fail wrong block height"),
+
+    Response.fail_no_permission:
+        (Response.fail_no_permission, "fail no permission"),
 
     Response.fail_tx_invalid_unknown:
         (Response.fail_tx_invalid_unknown, "fail tx invalid unknown"),

--- a/loopchain/statemachine/statemachine.py
+++ b/loopchain/statemachine/statemachine.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from transitions import Machine
+
+from transitions.extensions import LockedMachine as Machine
 
 import loopchain.utils as util
 


### PR DESCRIPTION
- Switch role from Citizen to Rep when a block of specific height is added.
- Reset network with state machine.
- ResetNetwork -> EvaluateNetwork -> ...
- create_icx_tx() function return fail_no_permission if node is citizen.
  (RPCServer always call create_icx_tx. if fail_no_permission is returned, RPCServer redirect the tx to parent node) 