### PR TITLE
[LC-379] Add a vote of a new leader for `last_unconfirmed_block` to vote_queue in `consensus.py`.

### DIFF
--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -799,13 +799,12 @@ class ChannelInnerTask:
             (False, True)[vote_code == message_code.Response.success_validate_block]
         )
 
-        if self._channel_service.state_machine.state == "BlockGenerate":
-            if block_manager.consensus_algorithm:
-                block_manager.consensus_algorithm.vote(
-                    block_hash,
-                    (False, True)[vote_code == message_code.Response.success_validate_block],
-                    peer_id,
-                    group_id)
+        if self._channel_service.state_machine.state == "BlockGenerate" and block_manager.consensus_algorithm:
+            block_manager.consensus_algorithm.vote(
+                block_hash,
+                (False, True)[vote_code == message_code.Response.success_validate_block],
+                peer_id,
+                group_id)
 
     @message_queue_task(type_=MessageQueueType.Worker)
     async def complain_leader(self, complained_leader_id, new_leader_id, block_height, peer_id, group_id) -> None:

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -828,7 +828,13 @@ class BlockManager:
             self.set_invoke_results(unconfirmed_block.header.hash.hex(), invoke_results)
             self.candidate_blocks.add_block(unconfirmed_block)
         finally:
-            self.vote_unconfirmed_block(unconfirmed_block.header.hash, exc is None)
+            is_validate = exc is None
+            self.vote_unconfirmed_block(unconfirmed_block.header.hash, is_validate)
+            if self.__channel_service.state_machine.state == "BlockGenerate" and self.consensus_algorithm:
+                self.consensus_algorithm.vote(unconfirmed_block.header.hash,
+                                              (False, True)[is_validate],
+                                              ChannelProperty().peer_id,
+                                              ChannelProperty().group_id)
 
     async def vote_as_peer(self, unconfirmed_block: Block):
         """Vote to AnnounceUnconfirmedBlock


### PR DESCRIPTION
I fix the bug that a vote of a new leader for a last unconfirmed block could be lost after rotation of leader.
I tried to add a vote of the new leader for `last_unconfirmed_block` to vote_queue in `consensus.py` when a new leader votes to a last unconfirmed block. 
