### PR TITLE
[LC-306] Use all header properties to generate block hash

### DIFF
--- a/loopchain/blockchain/blocks/block_verifier.py
+++ b/loopchain/blockchain/blocks/block_verifier.py
@@ -66,7 +66,7 @@ class BlockVerifier(ABC):
 
         self.verify_version(block)
 
-        if block.header.height > 0:
+        if block.header.signature or block.header.height > 0:
             self.verify_signature(block)
 
         if prev_block:

--- a/loopchain/blockchain/blocks/v0_3/block_builder.py
+++ b/loopchain/blockchain/blocks/v0_3/block_builder.py
@@ -212,6 +212,7 @@ class BlockBuilder(BaseBlockBuilder):
             self.height,
             self._timestamp,
             self.peer_id,
+            self.next_leader
         )
         block_prover = BlockProver(leaves, BlockProverType.Block)
         return block_prover.get_proof_root()

--- a/loopchain/blockchain/blocks/v0_3/block_builder.py
+++ b/loopchain/blockchain/blocks/v0_3/block_builder.py
@@ -201,6 +201,8 @@ class BlockBuilder(BaseBlockBuilder):
         leaves = (
             self.prev_hash,
             self.transactions_hash,
+            self.receipts_hash,
+            self.state_hash,
             self.reps_hash,
             self.leader_votes_hash,
             self.prev_votes_hash,

--- a/loopchain/blockchain/blocks/v0_3/block_builder.py
+++ b/loopchain/blockchain/blocks/v0_3/block_builder.py
@@ -50,6 +50,8 @@ class BlockBuilder(BaseBlockBuilder):
             raise RuntimeError("Transactions and Receipts are not matched.")
 
         self._receipts = [dict(receipts[tx_hash.hex()]) for tx_hash in self.transactions]
+        for receipt in self._receipts:
+            receipt.pop("blockHash", None)
 
     def reset_cache(self):
         super().reset_cache()

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -756,8 +756,11 @@ class ChannelService:
         else:
             block_builder.signature = block.header.signature
         new_block = block_builder.build()
-
         self.__block_manager.set_old_block_hash(new_block.header.hash, block.header.hash)
+
+        for tx_receipt in tx_receipts.values():
+            tx_receipt["blockHash"] = new_block.header.hash.hex()
+
         return new_block, tx_receipts
 
     def score_invoke(self, _block: Block) -> dict or None:
@@ -802,8 +805,11 @@ class ChannelService:
         else:
             block_builder.signature = _block.header.signature
         new_block = block_builder.build()
-
         self.__block_manager.set_old_block_hash(new_block.header.hash, _block.header.hash)
+
+        for tx_receipt in tx_receipts.values():
+            tx_receipt["blockHash"] = new_block.header.hash.hex()
+
         return new_block, tx_receipts
 
     def score_change_block_hash(self, block_height, old_block_hash, new_block_hash):

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -756,7 +756,7 @@ class ChannelService:
         else:
             block_builder.signature = block.header.signature
         new_block = block_builder.build()
-        self.__block_manager.set_old_block_hash(new_block.header.hash, block.header.hash)
+        self.__block_manager.set_old_block_hash(new_block.header.height, new_block.header.hash, block.header.hash)
 
         for tx_receipt in tx_receipts.values():
             tx_receipt["blockHash"] = new_block.header.hash.hex()
@@ -805,7 +805,7 @@ class ChannelService:
         else:
             block_builder.signature = _block.header.signature
         new_block = block_builder.build()
-        self.__block_manager.set_old_block_hash(new_block.header.hash, _block.header.hash)
+        self.__block_manager.set_old_block_hash(new_block.header.height, new_block.header.hash, _block.header.hash)
 
         for tx_receipt in tx_receipts.values():
             tx_receipt["blockHash"] = new_block.header.hash.hex()
@@ -824,7 +824,7 @@ class ChannelService:
 
         new_block_hash = block.header.hash
         try:
-            old_block_hash = self.__block_manager.get_old_block_hash(new_block_hash)
+            old_block_hash = self.__block_manager.get_old_block_hash(block.header.height, new_block_hash)
         except KeyError:
             old_block_hash = new_block_hash
 
@@ -839,7 +839,7 @@ class ChannelService:
         stub = StubCollection().icon_score_stubs[ChannelProperty().name]
         stub.sync_task().write_precommit_state(request)
 
-        self.__block_manager.pop_old_block_hash(new_block_hash)
+        self.__block_manager.pop_old_block_hashes(block.header.height)
         return True
 
     def score_remove_precommit_state(self, block: Block):

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -19,7 +19,7 @@ import shutil
 import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor, Future
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 import loopchain.utils as util
 from loopchain import configure as conf
@@ -73,6 +73,7 @@ class BlockManager:
         self.__block_height_sync_lock = threading.Lock()
         self.__block_height_thread_pool = ThreadPoolExecutor(1, 'BlockHeightSyncThread')
         self.__block_height_future: Future = None
+        self.__old_block_hashes: Dict[Hash32, Hash32] = {}
         self.__precommit_block: Block = None
         self.set_peer_type(loopchain_pb2.PEER)
         self.name = name
@@ -141,6 +142,15 @@ class BlockManager:
 
     def set_invoke_results(self, block_hash, invoke_results):
         self.__blockchain.set_invoke_results(block_hash, invoke_results)
+
+    def set_old_block_hash(self, new_block_hash: Hash32, old_block_hash: Hash32):
+        self.__old_block_hashes[new_block_hash] = old_block_hash
+
+    def get_old_block_hash(self, new_block_hash: Hash32):
+        return self.__old_block_hashes[new_block_hash]
+
+    def pop_old_block_hash(self, new_block_hash: Hash32):
+        self.__old_block_hashes.pop(new_block_hash)
 
     def get_total_tx(self):
         """

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -19,7 +19,8 @@ import shutil
 import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor, Future
-from typing import TYPE_CHECKING, Dict
+from collections import defaultdict
+from typing import TYPE_CHECKING, Dict, DefaultDict
 
 import loopchain.utils as util
 from loopchain import configure as conf
@@ -73,12 +74,13 @@ class BlockManager:
         self.__block_height_sync_lock = threading.Lock()
         self.__block_height_thread_pool = ThreadPoolExecutor(1, 'BlockHeightSyncThread')
         self.__block_height_future: Future = None
-        self.__old_block_hashes: Dict[Hash32, Hash32] = {}
         self.__precommit_block: Block = None
         self.set_peer_type(loopchain_pb2.PEER)
         self.name = name
         self.__service_status = status_code.Service.online
 
+        # old_block_hashes[height][new_block_hash] = old_block_hash
+        self.__old_block_hashes: DefaultDict[int, Dict[Hash32, Hash32]] = defaultdict(dict)
         self.epoch: Epoch = None
 
     @property
@@ -143,14 +145,14 @@ class BlockManager:
     def set_invoke_results(self, block_hash, invoke_results):
         self.__blockchain.set_invoke_results(block_hash, invoke_results)
 
-    def set_old_block_hash(self, new_block_hash: Hash32, old_block_hash: Hash32):
-        self.__old_block_hashes[new_block_hash] = old_block_hash
+    def set_old_block_hash(self, block_height: int, new_block_hash: Hash32, old_block_hash: Hash32):
+        self.__old_block_hashes[block_height][new_block_hash] = old_block_hash
 
-    def get_old_block_hash(self, new_block_hash: Hash32):
-        return self.__old_block_hashes[new_block_hash]
+    def get_old_block_hash(self,  block_height: int, new_block_hash: Hash32):
+        return self.__old_block_hashes[block_height][new_block_hash]
 
-    def pop_old_block_hash(self, new_block_hash: Hash32):
-        self.__old_block_hashes.pop(new_block_hash)
+    def pop_old_block_hashes(self, block_height: int):
+        self.__old_block_hashes.pop(block_height)
 
     def get_total_tx(self):
         """


### PR DESCRIPTION
- Use all header properties to generate block hash
- Change temporary hash to confirmed hash
- Resign when building a new block to rehash the block.