### PR TITLE
[LC-399] add private_password configuration to keystore

### DIFF
--- a/loopchain/configure_default.py
+++ b/loopchain/configure_default.py
@@ -400,7 +400,7 @@ CHANNEL_OPTION = {
 
 PUBLIC_PATH = os.path.join(LOOPCHAIN_ROOT_PATH, 'resources/default_pki/public.der')
 PRIVATE_PATH = os.path.join(LOOPCHAIN_ROOT_PATH, 'resources/default_pki/private.der')
-PRIVATE_PASSWORD = b'test'
+PRIVATE_PASSWORD = None
 
 # KMS
 KMS_AGENT_PASSWORD = ""

--- a/loopchain/crypto/signature.py
+++ b/loopchain/crypto/signature.py
@@ -183,13 +183,13 @@ class Signer(SignVerifier):
             prikey_file = conf.CHANNEL_OPTION[channel]['private_path']
         else:
             prikey_file = conf.PRIVATE_PATH
-        if prikey_file.endswith(".der") or prikey_file.endswith(".pem"):
-            if 'private_password' in conf.CHANNEL_OPTION[channel]:
-                logging.warning(f"This setting(private_password) will be deprecated soon. "
-                                f"Please refer to the key configuration guide.")
-                password = conf.CHANNEL_OPTION[channel]['private_password']
-            else:
-                password = conf.PRIVATE_PASSWORD
+
+        if 'private_password' in conf.CHANNEL_OPTION[channel]:
+            logging.warning(f"This setting(private_password) will be deprecated soon. "
+                            f"Please refer to the key configuration guide.")
+            password = conf.CHANNEL_OPTION[channel]['private_password']
+        elif conf.PRIVATE_PASSWORD:
+            password = conf.PRIVATE_PASSWORD
         else:
             # created the private key file from tbears.
             password = getpass.getpass(f"Input your keystore password for channel({channel}): ")

--- a/testcase/unittest/mock_peer.py
+++ b/testcase/unittest/mock_peer.py
@@ -1,8 +1,10 @@
+import os
+
+from loopchain import configure as conf
 from loopchain.baseservice import ScoreResponse, PeerInfo, PeerStatus, PeerObject, ObjectManager
 from loopchain.baseservice.aging_cache import AgingCache
-from loopchain.blockchain import Block
-from loopchain import configure as conf
-from testcase.unittest import test_util
+from loopchain.blockchain.blocks import Block
+from loopchain.crypto.signature import Signer
 
 
 class Mock:
@@ -53,7 +55,7 @@ class PeerManagerMock:
 
 
 def set_mock(test):
-    peer_auth = test_util.create_default_peer_auth()
+    peer_auth = Signer.from_prikey(os.urandom(32))
     test.peer_auth = peer_auth
     peer_service_mock = PeerServiceMock()
     peer_service_mock.peer_manager = PeerManagerMock(peer_auth)

--- a/testcase/unittest/test_block.py
+++ b/testcase/unittest/test_block.py
@@ -18,6 +18,7 @@
 
 import logging
 import json
+import os
 import random
 import sys
 import unittest
@@ -28,6 +29,7 @@ import testcase.unittest.test_util as test_util
 from cli_tools.icx_test.icx_wallet import IcxWallet
 from loopchain import configure as conf
 from loopchain.baseservice import ObjectManager
+from loopchain.crypto.signature import Signer
 from testcase.unittest.mock_peer import set_mock
 
 sys.path.append('../')
@@ -48,7 +50,7 @@ class TestBlock(unittest.TestCase):
     def setUp(self):
         conf.Configure().init_configure()
         test_util.print_testname(self._testMethodName)
-        self.peer_auth = test_util.create_default_peer_auth()
+        self.peer_auth = Signer.from_prikey(os.urandom(32))
         set_mock(self)
 
     def tearDown(self):
@@ -222,14 +224,14 @@ class TestBlock(unittest.TestCase):
             tx_validator.refresh_tx_validators()
 
     def test_block_v0_3(self):
-        private_auth = test_util.create_default_peer_auth()
+        test_signer = Signer.from_prikey(os.urandom(32))
         tx_versioner = TransactionVersioner()
 
         dummy_receipts = {}
         block_builder = BlockBuilder.new("0.3", tx_versioner)
         for i in range(1000):
             tx_builder = TransactionBuilder.new("0x3", tx_versioner)
-            tx_builder.signer = private_auth
+            tx_builder.signer = test_signer
             tx_builder.to_address = ExternalAddress.new()
             tx_builder.step_limit = random.randint(0, 10000)
             tx_builder.value = random.randint(0, 10000)
@@ -243,12 +245,12 @@ class TestBlock(unittest.TestCase):
                 "tx_dumped": tx_serializer.to_full_data(tx)
             }
 
-        block_builder.signer = private_auth
+        block_builder.signer = test_signer
         block_builder.height = 3
         block_builder.prev_hash = Hash32(bytes(Hash32.size))
         block_builder.state_hash = Hash32(bytes(Hash32.size))
         block_builder.receipts = dummy_receipts
-        block_builder.reps = [ExternalAddress.fromhex_address(private_auth.address)]
+        block_builder.reps = [ExternalAddress.fromhex_address(test_signer.address)]
         block_builder.next_leader = ExternalAddress.fromhex("hx00112233445566778899aabbccddeeff00112233")
 
         block = block_builder.build()

--- a/testcase/unittest/test_blockchain.py
+++ b/testcase/unittest/test_blockchain.py
@@ -26,7 +26,8 @@ import loopchain.utils as util
 import testcase.unittest.test_util as test_util
 from loopchain import configure as conf
 from loopchain.baseservice import ObjectManager, ScoreResponse
-from loopchain.blockchain import Block
+from loopchain.blockchain.blocks import Block
+from loopchain.crypto.signature import Signer
 from loopchain.utils import loggers
 from testcase.unittest.mock_peer import set_mock
 
@@ -43,7 +44,7 @@ class TestBlockChain(unittest.TestCase):
 
     def setUp(self):
         test_util.print_testname(self._testMethodName)
-        self.peer_auth = test_util.create_default_peer_auth()
+        self.peer_auth = Signer.from_prikey(os.urandom(32))
 
         set_mock(self)
         # BlockChain 을 만듬

--- a/testcase/unittest/test_generator_block.py
+++ b/testcase/unittest/test_generator_block.py
@@ -18,11 +18,13 @@
 
 import leveldb
 import logging
+import os
 import unittest
 
 import testcase.unittest.test_util as test_util
 from loopchain import configure as conf
-from loopchain.blockchain import Block
+from loopchain.blockchain.blocks import Block
+from loopchain.crypto.signature import Signer
 from loopchain.utils import loggers
 from testcase.unittest.mock_peer import set_mock
 
@@ -37,7 +39,7 @@ class TestGeneratorBlock(unittest.TestCase):
 
     def setUp(self):
         test_util.print_testname(self._testMethodName)
-        self.peer_auth = test_util.create_default_peer_auth()
+        self.peer_auth = Signer.from_prikey(os.urandom(32))
 
         set_mock(self)
 

--- a/testcase/unittest/test_util.py
+++ b/testcase/unittest/test_util.py
@@ -247,12 +247,6 @@ def create_basic_tx(peer_auth: Signer) -> Transaction:
     return tx_builder.build()
 
 
-def create_default_peer_auth() -> Signer:
-    channel = list(conf.CHANNEL_OPTION)[0]
-    peer_auth = Signer.from_channel(channel)
-    return peer_auth
-
-
 def add_genesis_block():
     tx_info = None
     channel = conf.LOOPCHAIN_DEFAULT_CHANNEL


### PR DESCRIPTION
Now password can be placed in configuration file (not only in prompt) when running a node with keystore file.