### PR TITLE
[LC-405] Add `LeaderComplain` state to the source state of `block_sync`.

### DIFF
--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -57,8 +57,10 @@ class ChannelStateMachine(object):
     def __init__(self, channel_service):
         self.__channel_service = channel_service
 
-        self.machine.add_transition('complete_subscribe', 'SubscribeNetwork', 'BlockGenerate', conditions=['_is_leader'])
-        self.machine.add_transition('complete_subscribe', 'SubscribeNetwork', 'Watch', conditions=['_has_no_vote_function'])
+        self.machine.add_transition(
+            'complete_subscribe', 'SubscribeNetwork', 'BlockGenerate', conditions=['_is_leader'])
+        self.machine.add_transition(
+            'complete_subscribe', 'SubscribeNetwork', 'Watch', conditions=['_has_no_vote_function'])
         self.machine.add_transition('complete_subscribe', 'SubscribeNetwork', 'Vote')
 
     @statemachine.transition(source='InitComponents', dest='Consensus')
@@ -75,7 +77,7 @@ class ChannelStateMachine(object):
     def evaluate_network(self):
         pass
 
-    @statemachine.transition(source=('EvaluateNetwork', 'Vote', 'BlockSync', 'BlockGenerate'),
+    @statemachine.transition(source=('EvaluateNetwork', 'Vote', 'BlockSync', 'BlockGenerate', 'LeaderComplain'),
                              dest='BlockSync',
                              after='_do_block_sync')
     def block_sync(self):


### PR DESCRIPTION
A node in state of `LeaderComplain` can't be changed to `BlockSync`, that's why the node can't participate to consensus.
I add `LeaderComplain` state to the source state of `BlockSync` for resolve above problem.