### PR TITLE
[LC-414] fix bug on BlockHeightSync & Watch state

### DIFF
--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Class for websocket client between child node and RS peer"""
+"""Class for websocket client between child node and parent node"""
 
 import asyncio
 import json
@@ -27,7 +27,7 @@ from jsonrpcserver.aio import AsyncMethods
 from loopchain import configure as conf
 from loopchain import utils
 from loopchain.baseservice import ObjectManager, TimerService, Timer
-from loopchain.blockchain import BlockSerializer, BlockVerifier
+from loopchain.blockchain import BlockSerializer, BlockVerifier, AnnounceNewBlockError
 from loopchain.channel.channel_property import ChannelProperty
 from loopchain.protos import message_code
 
@@ -40,38 +40,39 @@ CONNECTION_FAIL_CONDITIONS = {message_code.Response.fail_subscribe_limit,
 
 class NodeSubscriber:
     def __init__(self, channel, rs_target):
-        self.__channel = channel
-        self.__rs_target = rs_target
-        self.__target_uri = f"{'wss' if conf.SUBSCRIBE_USE_HTTPS else 'ws'}://{self.__rs_target}/api/ws/{channel}"
-        self.__exception = None
-        self.__websocket = None
-        self.__subscribe_event: Event = None
+        self._target_uri = f"{'wss' if conf.SUBSCRIBE_USE_HTTPS else 'ws'}://{rs_target}/api/ws/{channel}"
+        self._exception = None
+        self._websocket = None
+        self._subscribe_event: Event = None
 
         ws_methods.add(self.node_ws_PublishHeartbeat)
         ws_methods.add(self.node_ws_PublishNewBlock)
 
-        logging.debug(f"websocket target uri : {self.__target_uri}")
+        logging.debug(f"websocket target uri : {self._target_uri}")
 
     def __del__(self):
-        if self.__websocket is not None:
+        if self._websocket is not None:
             utils.logger.warning(f"Have to close before delete NodeSubscriber instance({self})")
 
     async def close(self):
-        if self.__websocket is not None:
-            await self.__websocket.close()
-            self.__websocket = None
+        if self._websocket is not None:
+            websocket = self._websocket
+            self._websocket = None
+            await websocket.close()
 
     async def subscribe(self, block_height, event: Event):
-        self.__exception = None
-        self.__subscribe_event = event
+        self._exception = None
+        self._subscribe_event = event
 
         try:
             # set websocket payload maxsize to 4MB.
-            self.__websocket = await websockets.connect(self.__target_uri, max_size=4 * conf.MAX_TX_SIZE_IN_BLOCK)
+            self._websocket = await websockets.connect(self._target_uri, max_size=4 * conf.MAX_TX_SIZE_IN_BLOCK)
             logging.debug(f"Websocket connection is Completed.")
             request = Request("node_ws_Subscribe", height=block_height, peer_id=ChannelProperty().peer_id)
-            await self.__websocket.send(json.dumps(request))
-            await self.__subscribe_loop(self.__websocket)
+            await self._websocket.send(json.dumps(request))
+            await self._subscribe_loop(self._websocket)
+        except AnnounceNewBlockError:
+            raise
         except Exception as e:
             traceback.print_exc()
             logging.error(f"websocket subscribe exception, caused by: {type(e)}, {e}")
@@ -79,10 +80,10 @@ class NodeSubscriber:
         finally:
             await self.close()
 
-    async def __subscribe_loop(self, websocket):
+    async def _subscribe_loop(self, websocket):
         while True:
-            if self.__exception:
-                raise self.__exception
+            if self._exception:
+                raise self._exception
 
             try:
                 response = await asyncio.wait_for(websocket.recv(), timeout=2 * conf.TIMEOUT_FOR_WS_HEARTBEAT)
@@ -95,7 +96,7 @@ class NodeSubscriber:
     async def node_ws_PublishNewBlock(self, **kwargs):
         if 'error' in kwargs:
             if kwargs.get('code') in CONNECTION_FAIL_CONDITIONS:
-                self.__exception = ConnectionError(kwargs['error'])
+                self._exception = ConnectionError(kwargs['error'])
                 return
             else:
                 return ObjectManager().channel_service.shutdown_peer(message=kwargs.get('error'))
@@ -113,28 +114,31 @@ class NodeSubscriber:
             block_verifier = BlockVerifier.new(block_version, blockchain.tx_versioner)
             block_verifier.invoke_func = ObjectManager().channel_service.score_invoke
             reps = ObjectManager().channel_service.get_rep_ids()
-            block_verifier.verify(confirmed_block,
-                                  blockchain.last_block,
-                                  blockchain,
-                                  blockchain.last_block.header.next_leader,
-                                  reps=reps)
-
-            logging.debug(f"add_confirmed_block height({confirmed_block.header.height}), "
-                          f"hash({confirmed_block.header.hash.hex()}), confirm_info({confirm_info})")
-
-            ObjectManager().channel_service.block_manager.add_confirmed_block(confirmed_block=confirmed_block,
-                                                                              confirm_info=confirm_info)
+            try:
+                block_verifier.verify(confirmed_block,
+                                      blockchain.last_block,
+                                      blockchain,
+                                      blockchain.last_block.header.next_leader,
+                                      reps=reps)
+            except Exception as e:
+                self._exception = AnnounceNewBlockError(f"error: {type(e)}, message: {str(e)}")
+            else:
+                logging.debug(f"add_confirmed_block height({confirmed_block.header.height}), "
+                              f"hash({confirmed_block.header.hash.hex()}), confirm_info({confirm_info})")
+                ObjectManager().channel_service.block_manager.add_confirmed_block(confirmed_block=confirmed_block,
+                                                                                  confirm_info=confirm_info)
 
     async def node_ws_PublishHeartbeat(self, **kwargs):
         def _callback(exception):
-            self.__exception = exception
+            self._exception = exception
 
         if 'error' in kwargs:
             _callback(ConnectionError(kwargs['error']))
             return
 
-        if not self.__subscribe_event.is_set():
-            self.__subscribe_event.set()
+        if not self._subscribe_event.is_set():
+            self._subscribe_event.set()
+
         timer_key = TimerService.TIMER_KEY_WS_HEARTBEAT
         timer_service = ObjectManager().channel_service.timer_service
         if timer_key in timer_service.timer_list:

--- a/loopchain/baseservice/peer_manager.py
+++ b/loopchain/baseservice/peer_manager.py
@@ -289,7 +289,7 @@ class PeerManager:
             if is_complain_to_rs:
                 return self.leader_complain_to_rs(search_group)
             else:
-                if is_peer and ObjectManager().peer_service.is_support_node_function(conf.NodeFunction.Vote):
+                if is_peer and ObjectManager().channel_service.is_support_node_function(conf.NodeFunction.Vote):
                     util.exit_and_msg(f"Fail to find a leader of this network.... {e}")
 
         return None
@@ -300,6 +300,9 @@ class PeerManager:
         :param search_group:
         :return: leader peer_id
         """
+        if not ObjectManager().channel_service.is_support_node_function(conf.NodeFunction.Vote):
+            return None
+
         leader_peer_order = self.peer_leader[search_group]
         logging.debug(f"peer_manager:get_leader_id leader peer order {leader_peer_order}")
         # util.logger.spam(f"peer_manager:get_leader_id peer_order_list({self.peer_order_list})")
@@ -705,7 +708,7 @@ class PeerManager:
                 logging.debug(self.get_peers_for_debug(group_id))
                 return None
             else:
-                logging.info(f"This node({peer_id}) will run as {conf.NodeType.CitizenNode.name}")
+                logging.debug(f"This node({peer_id}) will run as {conf.NodeType.CitizenNode.name}")
                 return None
         except IndexError:
             logging.warning(f"there is no peer by id({str(peer_id)}) group_id({group_id})")

--- a/loopchain/baseservice/rest_stub_manager.py
+++ b/loopchain/baseservice/rest_stub_manager.py
@@ -13,13 +13,11 @@
 # limitations under the License.
 """A stub wrapper for REST call.
 This object has same interface with gRPC stub manager"""
-
 import logging
-import requests
-
 from concurrent.futures import ThreadPoolExecutor
-from jsonrpcclient.exceptions import ReceivedErrorResponse
-from jsonrpcclient.http_client import HTTPClient
+
+import requests
+from jsonrpcclient import HTTPClient, Request
 
 import loopchain.utils as util
 from loopchain import configure as conf
@@ -28,54 +26,59 @@ from loopchain import configure as conf
 class RestStubManager:
     def __init__(self, target, channel=None, for_rs_target=True):
         util.logger.spam(f"RestStubManager:init target({target})")
-        if channel is None:
-            channel = conf.LOOPCHAIN_DEFAULT_CHANNEL
-
-        self.__channel_name = channel
-        self.target = target
-
-        self.__version_urls = {}
+        self._channel_name = channel or conf.LOOPCHAIN_DEFAULT_CHANNEL
+        self._version_urls = {}
+        self._http_clients = {}
         for version in conf.ApiVersion:
             if 'https://' in target:
-                url = util.normalize_request_url(target, version, channel)
+                url = util.normalize_request_url(target, version, self._channel_name)
             elif for_rs_target:
                 url = util.normalize_request_url(
-                    f"{'https' if conf.SUBSCRIBE_USE_HTTPS else 'http'}://{target}", version, channel)
+                    f"{'https' if conf.SUBSCRIBE_USE_HTTPS else 'http'}://{target}", version, self._channel_name)
             else:
-                url = util.normalize_request_url(f"http://{target}", version, channel)
-            self.__version_urls[version] = url
+                url = util.normalize_request_url(f"http://{target}", version, self._channel_name)
+            self._version_urls[version] = url
+            if version != conf.ApiVersion.v1:
+                self._http_clients[url] = HTTPClient(url)
 
-        self.__method_versions = {
+        self._method_versions = {
             "GetChannelInfos": conf.ApiVersion.node,
             "GetBlockByHeight": conf.ApiVersion.node,
             "Status": conf.ApiVersion.v1,
             "GetLastBlock": conf.ApiVersion.v3
         }
 
-        self.__method_names = {
+        self._method_names = {
             "GetChannelInfos": "node_getChannelInfos",
             "GetBlockByHeight": "node_getBlockByHeight",
             "Status": "/status/peer/",
             "GetLastBlock": "icx_getLastBlock"
         }
 
-        self.__executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="RestStubThread")
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="RestStubThread")
 
-    def call(self, method_name, message=None, timeout=None, is_stub_reuse=True, is_raise=False):
+    def call(self, method_name, message=None, timeout=None, is_stub_reuse=True, is_raise=False) -> dict:
         try:
-            version = self.__method_versions[method_name]
-            url = self.__version_urls[version]
-            method_name = self.__method_names[method_name]
+            version = self._method_versions[method_name]
+            url = self._version_urls[version]
+            method_name = self._method_names[method_name]
 
             if version == conf.ApiVersion.v1:
                 url += method_name
-                response = requests.get(url, params={'channel': self.__channel_name})
+                response = requests.get(url=url,
+                                        params={'channel': self._channel_name},
+                                        timeout=conf.REST_ADDITIONAL_TIMEOUT)
+                if response.status_code != 200:
+                    raise ConnectionError
+                response = response.json()
             else:
-                client = HTTPClient(url)
-                client.session.verify = conf.REST_SSL_VERIFY
-                response = client.request(method_name, message) if message else client.request(method_name)
-            util.logger.spam(f"RestStubManager:call complete request_url({url}), "
-                             f"method_name({method_name})")
+                # using jsonRPC client request.
+                if message:
+                    request = Request(method_name, message)
+                else:
+                    request = Request(method_name)
+                response = self._http_clients[url].send(request, timeout=conf.REST_ADDITIONAL_TIMEOUT)
+            util.logger.spam(f"REST call complete request_url({url}), method_name({method_name})")
             return response
 
         except Exception as e:
@@ -83,7 +86,7 @@ class RestStubManager:
             raise e
 
     def call_async(self, method_name, message=None, call_back=None, timeout=None, is_stub_reuse=True):
-        future = self.__executor.submit(self.call, method_name, message, timeout, is_stub_reuse)
+        future = self._executor.submit(self.call, method_name, message, timeout, is_stub_reuse)
         if call_back:
             future.add_done_callback(call_back)
         return future
@@ -99,4 +102,3 @@ class RestStubManager:
                 exception = e
 
         raise exception
-

--- a/loopchain/baseservice/rest_stub_manager.py
+++ b/loopchain/baseservice/rest_stub_manager.py
@@ -18,7 +18,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 import requests
 from jsonrpcclient import HTTPClient, Request
-from jsonrpcclient.exceptions import ParseResponseError
 
 import loopchain.utils as util
 from loopchain import configure as conf
@@ -81,10 +80,8 @@ class RestStubManager:
 
                 try:
                     response = self._http_clients[url].send(request, timeout=conf.REST_ADDITIONAL_TIMEOUT)
-                except ParseResponseError as e:
-                    raise ConnectionError(str(e))
-                except Exception:
-                    raise
+                except Exception as e:
+                    raise ConnectionError(e)
             util.logger.spam(f"REST call complete request_url({url}), method_name({method_name})")
             return response
 

--- a/loopchain/blockchain/exception.py
+++ b/loopchain/blockchain/exception.py
@@ -71,6 +71,10 @@ class DuplicationUnconfirmedBlock(Exception):
     pass
 
 
+class AnnounceNewBlockError(Exception):
+    message_code = message_code.Response.fail_announce_block
+
+
 class BlockVersionNotMatch(Exception):
     def __init__(self, block_version: str, target_version: str, msg: str):
         super().__init__(msg)

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -517,6 +517,9 @@ class ChannelInnerTask:
     async def register_citizen(self, peer_id, target, connected_time):
         if len(self._citizens) >= conf.SUBSCRIBE_LIMIT:
             return False
+        elif peer_id in self._citizens:
+            logging.warning(f"Already registered citizen({peer_id})")
+            return False
         else:
             new_citizen = self._CitizenInfo(peer_id, target, connected_time)
             self._citizens[peer_id] = new_citizen
@@ -570,7 +573,8 @@ class ChannelInnerTask:
 
         status_data["status"] = block_manager.service_status
         status_data["state"] = self._channel_service.state_machine.state
-        status_data["service_available"]: bool = status_data["state"] in self._channel_service.state_machine.service_available_states
+        status_data["service_available"]: bool = (status_data["state"] in
+                                                  self._channel_service.state_machine.service_available_states)
         status_data["peer_type"] = str(1 if self._channel_service.state_machine.state == "BlockGenerate" else 0)
         status_data["audience_count"] = "0"
         status_data["consensus"] = str(conf.CONSENSUS_ALGORITHM.name)

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -490,7 +490,7 @@ class ChannelInnerTask:
         return 'channel_hello'
 
     @message_queue_task
-    async def announce_new_block(self, subscriber_block_height: int):
+    async def announce_new_block(self, subscriber_block_height: int, subscriber_id: str):
         blockchain = self._channel_service.block_manager.get_blockchain()
 
         while True:
@@ -508,8 +508,7 @@ class ChannelInnerTask:
                 await asyncio.sleep(0.5)  # To prevent excessive occupancy of the CPU in an infinite loop
                 continue
 
-            logging.debug(f"announce_new_block: height({new_block.header.height}), hash({new_block.header.hash}), "
-                          f"target: {self._citizens}")
+            logging.debug(f"announce_new_block: height({new_block.header.height}), to: {subscriber_id}")
             bs = BlockSerializer.new(new_block.header.version, blockchain.tx_versioner)
             return json.dumps(bs.serialize(new_block)), confirm_info
 

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -28,7 +28,7 @@ from loopchain.baseservice import BroadcastScheduler, BroadcastSchedulerFactory,
 from loopchain.baseservice import ObjectManager, CommonSubprocess
 from loopchain.baseservice import RestStubManager, NodeSubscriber
 from loopchain.baseservice import StubManager, PeerManager, PeerListData, PeerStatus, TimerService
-from loopchain.blockchain import Block, BlockBuilder, TransactionSerializer, Hash32, Epoch
+from loopchain.blockchain import Block, BlockBuilder, TransactionSerializer, Hash32, Epoch, AnnounceNewBlockError
 from loopchain.blockchain import ExternalAddress, TransactionStatusInQueue
 from loopchain.channel.channel_inner_service import ChannelInnerService
 from loopchain.channel.channel_property import ChannelProperty
@@ -221,8 +221,6 @@ class ChannelService:
                 self.connect_to_radio_station()
             else:
                 await self.__load_peers_from_file()
-        else:
-            self.__init_node_subscriber()
 
     async def evaluate_network(self):
         self.__ready_to_height_sync()
@@ -237,7 +235,8 @@ class ChannelService:
         if self.is_support_node_function(conf.NodeFunction.Vote):
             await self.set_peer_type_in_channel()
         else:
-            await self.subscribe_to_radio_station()
+            self.__init_node_subscriber()
+            await self.subscribe_to_parent()
 
         self.__state_machine.complete_subscribe()
         self.turn_on_leader_complain_timer()
@@ -502,47 +501,16 @@ class ChannelService:
                 if each_peer.status == PeerStatus.connected:
                     self.__broadcast_scheduler.schedule_job(BroadcastCommand.SUBSCRIBE, each_peer.target)
 
-    def __subscribe_to_peer_list(self):
-        peer_object = self.peer_manager.get_peer(ChannelProperty().peer_id)
-        peer_request = loopchain_pb2.PeerRequest(
-            channel=ChannelProperty().name,
-            peer_target=ChannelProperty().peer_target,
-            peer_id=ChannelProperty().peer_id, group_id=ChannelProperty().group_id,
-            node_type=ChannelProperty().node_type,
-            peer_order=peer_object.order
-        )
-        self.__broadcast_scheduler.schedule_broadcast("Subscribe", peer_request)
-
-    async def subscribe_to_radio_station(self):
-        await self.__subscribe_call_to_stub(self.__radio_station_stub, loopchain_pb2.PEER)
-
-    async def subscribe_to_peer(self, peer_id, peer_type):
-        peer = self.peer_manager.get_peer(peer_id)
-        peer_stub = self.peer_manager.get_peer_stub_manager(peer)
-
-        await self.__subscribe_call_to_stub(peer_stub, peer_type)
-        self.__broadcast_scheduler.schedule_job(BroadcastCommand.SUBSCRIBE, peer_stub.target)
-
-    async def __subscribe_call_to_stub(self, peer_stub, peer_type):
-        if self.is_support_node_function(conf.NodeFunction.Vote):
-            await peer_stub.call_async(
-                "Subscribe",
-                loopchain_pb2.PeerRequest(
-                    channel=ChannelProperty().name,
-                    peer_target=ChannelProperty().peer_target, peer_type=peer_type,
-                    peer_id=ChannelProperty().peer_id, group_id=ChannelProperty().group_id,
-                    node_type=ChannelProperty().node_type
-                ),
-            )
-        else:
-            await self.__subscribe_call_from_citizen()
-
-    async def __subscribe_call_from_citizen(self):
+    async def subscribe_to_parent(self):
         def _handle_exception(future: asyncio.Future):
             logging.debug(f"error: {type(future.exception())}, {str(future.exception())}")
 
             if ChannelProperty().node_type != conf.NodeType.CitizenNode:
                 logging.debug(f"This node is not Citizen anymore.")
+                return
+
+            if isinstance(future.exception(), AnnounceNewBlockError):
+                self.__state_machine.block_sync()
                 return
 
             if future.exception():

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -40,7 +40,7 @@ class ChannelStateMachine(object):
                     on_enter='_blocksync_on_enter', on_exit='_blocksync_on_exit'),
               State(name='SubscribeNetwork', ignore_invalid_triggers=True,
                     on_enter='_subscribe_network_on_enter', on_exit='_subscribe_network_on_exit'),
-              'Watch',
+              State(name='Watch', ignore_invalid_triggers=True),
               State(name='Vote', ignore_invalid_triggers=True,
                     on_enter='_vote_on_enter', on_exit='_vote_on_exit'),
               State(name='BlockGenerate', ignore_invalid_triggers=True,
@@ -77,7 +77,7 @@ class ChannelStateMachine(object):
     def evaluate_network(self):
         pass
 
-    @statemachine.transition(source=('EvaluateNetwork', 'Vote', 'BlockSync', 'BlockGenerate', 'LeaderComplain'),
+    @statemachine.transition(source=('EvaluateNetwork', 'Watch', 'Vote', 'BlockSync', 'BlockGenerate', 'LeaderComplain'),
                              dest='BlockSync',
                              after='_do_block_sync')
     def block_sync(self):

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -411,7 +411,6 @@ class BlockManager:
                 Timer(
                     target=timer_key,
                     duration=conf.GET_LAST_BLOCK_TIMER,
-                    is_repeat=True,
                     callback=self.block_height_sync
                 )
             )
@@ -591,19 +590,19 @@ class BlockManager:
 
     def __block_height_sync(self):
         # Make Peer Stub List [peer_stub, ...] and get max_height of network
-        max_height, unconfirmed_block_height, peer_stubs = self.__get_peer_stub_list()
-
-        if self.__blockchain.last_unconfirmed_block is not None:
-            self.candidate_blocks.remove_block(self.__blockchain.last_unconfirmed_block.header.hash)
-        self.__blockchain.last_unconfirmed_block = None
-
-        my_height = self.__current_block_height()
-        logging.debug(f"in __block_height_sync max_height({max_height}), my_height({my_height})")
-
-        # prevent_next_block_mismatch until last_block_height in block DB. (excludes last_unconfirmed_block_height)
-        self.get_blockchain().prevent_next_block_mismatch(self.__blockchain.block_height + 1)
-
         try:
+            max_height, unconfirmed_block_height, peer_stubs = self.__get_peer_stub_list()
+
+            if self.__blockchain.last_unconfirmed_block is not None:
+                self.candidate_blocks.remove_block(self.__blockchain.last_unconfirmed_block.header.hash)
+            self.__blockchain.last_unconfirmed_block = None
+
+            my_height = self.__current_block_height()
+            logging.debug(f"in __block_height_sync max_height({max_height}), my_height({my_height})")
+
+            # prevent_next_block_mismatch until last_block_height in block DB. (excludes last_unconfirmed_block_height)
+            self.get_blockchain().prevent_next_block_mismatch(self.__blockchain.block_height + 1)
+
             if peer_stubs:
                 my_height, max_height = self.__block_request_to_peers_in_sync(peer_stubs,
                                                                               my_height,


### PR DESCRIPTION
- close websocket connection when AnnounceNewBlock Error and transit state to BlockSync.
- add timeout on jsonRPC call
- add subscriber_id in announce_new_block and reject duplicated subscribe request.
- remove is_repeat flag on start_block_height_sync timer and widely handle exception when block_height_sync.