### PR TITLE
[LC-283] Add basic integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -237,5 +237,10 @@ virtualenv-15.2.0-py2.py3-none-any.whl
 
 user.mk
 
+# Test related
+.xprocess/
+.hypothesis/
+.pytest_cache/
+
 # start with _
 _*/

--- a/Makefile
+++ b/Makefile
@@ -33,15 +33,20 @@ requirements:
 all: install generate
 
 # pip install packages & generate-proto
-develop: install generate-proto
+develop: install-dev generate-proto
 
 # pip install packages
-install:
+requires:
 	$(PIP_INSTALL) git+https://github.com/icon-project/icon-service.git@master
 	$(PIP_INSTALL) git+https://github.com/icon-project/icon-commons.git@master
 	$(PIP_INSTALL) git+https://github.com/icon-project/icon-rpc-server.git@master
 	$(PIP_INSTALL) tbears
+
+install: requires
 	$(PIP_INSTALL_REQUIREMENTS)
+
+install-dev: requires
+	$(PIP_INSTALL_REQUIREMENTS)[tests]
 
 # Generate python gRPC proto and generate a key
 generate: generate-proto generate-key
@@ -68,7 +73,7 @@ test:
 	@python3 -m unittest discover testcase/unittest/ -p "test_*.py" || exit -1
 
 # Clean all - clean-process clean-mq clean-pyc clean-db clean-log
-clean: clean-process clean-mq clean-pyc clean-db clean-log check
+clean: clean-process clean-mq clean-pyc clean-db clean-log clean-test check
 
 clean-process:
 	@pkill -f loop || true
@@ -99,6 +104,12 @@ clean-db:
 clean-log:
 	@echo "Cleaning up logs..."
 	@rm -rf log/
+
+clean-test:
+	@echo "Cleaning up test related cache..."
+	@rm -rf .hypothesis/
+	@rm -rf .xprocess/
+	@rm -rf .pytest_cache/
 
 # build
 build: clean-build

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup_options = {
     'packages': find_packages(),
     'license': "Apache License 2.0",
     'install_requires': requires,
+    'extras_require': {
+        'tests': ['iconsdk==1.1.0', 'pytest>=4.6.3', 'pytest-xprocess>=0.12.1'],
+    },
     'entry_points': {
         'console_scripts': [
             'loop=loopchain.__main__:main',

--- a/testcase/integration/conftest.py
+++ b/testcase/integration/conftest.py
@@ -7,6 +7,8 @@ import pytest
 from iconsdk.wallet.wallet import KeyWallet
 from xprocess import ProcessStarter
 
+port_channel_list = []
+
 
 def pytest_addoption(parser):
     """Set args for tests
@@ -18,6 +20,18 @@ def pytest_addoption(parser):
     parser.addoption("--channel-count", action="store", default=2, help="Number of channel to set in each peer.\n"
                                                                         "Each will be named as 'channel_[num]'.\n"
                                                                         "Use this option to test multi-channel.\n")
+
+
+def pytest_configure(config):
+    peer_count = int(config.getoption("--peer-count"))
+    channel_count = int(config.getoption("--channel-count"))
+
+    for peer_order in range(peer_count):
+        port = 9000 + (peer_order * 100)
+        for channel_num in range(channel_count):
+            port_channel_list.append([port, f"channel_{channel_num}"])
+
+    print("list made: ", port_channel_list)
 
 
 def _get_channel_setting() -> dict:

--- a/testcase/integration/conftest.py
+++ b/testcase/integration/conftest.py
@@ -1,0 +1,268 @@
+import itertools
+import json
+import os
+from functools import partial
+
+import pytest
+from iconsdk.wallet.wallet import KeyWallet
+from xprocess import ProcessStarter
+
+
+def pytest_addoption(parser):
+    """Set args for tests
+
+    >> pytest tests/integration [--opt]
+    """
+    parser.addoption("--peer-count", action="store", default=4, help="Number of peer to be tested")
+    parser.addoption("--peer-type", action="store", default="peer", help="Type of peer. ([peer|citizen])")
+    parser.addoption("--channel-count", action="store", default=2, help="Number of channel to set in each peer.\n"
+                                                                        "Each will be named as 'channel_[num]'.\n"
+                                                                        "Use this option to test multi-channel.\n")
+
+
+def _get_channel_setting() -> dict:
+    channel_setting = {
+        "block_versions": {
+            "0.1a": 0
+        },
+        "hash_versions": {
+            "genesis": 1,
+            "0x2": 1,
+            "0x3": 1
+        },
+        "load_cert": False,
+        "consensus_cert_use": False,
+        "tx_cert_use": False,
+        "key_load_type": 0,
+    }
+
+    return channel_setting
+
+
+def generate_addr(wallet_key_path: str, password: str = "password"):
+    """Generate address from given wallet path and password
+
+    Generally, the password set as "password"
+
+    Args:
+        wallet_key_path (str): Desired path of wallet key file
+        password (str): Desired password of wallet
+
+    Returns:
+        account_addr (str): Account address
+    """
+    wallet = KeyWallet.create()
+    wallet.store(wallet_key_path, password)
+    account_addr = KeyWallet.load(wallet_key_path, password).get_address()
+
+    return account_addr
+
+
+def generate_channel_manage_data(channel_manage_data_path: str, config_path_list: list):
+    """Generate channel_manage_data.json
+
+    Args:
+        channel_manage_data_path (str): Desired path of channel_manage_data.json
+        config_path_list (list): Peer infos to be contained to the json file
+
+    """
+    channel_manage_data = {}
+    peers = []
+
+    for config_path in config_path_list:
+        with open(config_path) as f:
+            each_config = json.load(f)
+
+        for channel_name in each_config["CHANNEL_OPTION"]:
+            channel_manage_data[channel_name] = {
+                "score_package": "score/icx",
+            }
+
+        each_peer = {
+            "id": each_config["PEER_ID"],
+            "peer_target": f"[local_ip]:{each_config['PORT_PEER']}",
+            "order": each_config["PEER_ORDER"]
+        }
+        peers.append(each_peer)
+
+    for channel_name in channel_manage_data:
+        channel_manage_data[channel_name]["peers"] = peers
+
+    with open(channel_manage_data_path, "w") as f:
+        json.dump(channel_manage_data, f)
+
+
+def generate_genesis_file(genesis_path: str, accounts: list):
+    """
+    Generate genesis file
+
+    It mimics genesis block tx.
+    It will be contained to genesis block in this test.
+
+    Args:
+        genesis_path (str): Desired path of genesis file
+        accounts (list): This will be contained to genesis tx. Sample schema is below.
+            [
+                {
+                    "name": "treasury",
+                    "address": "hx1000000000000000000000000000000000000000",
+                    "balance": "0x1111"
+                },
+                ...
+            ]
+    """
+    genesis_data = {
+        "transaction_data": {
+            "nid": "0x3",
+            "accounts": accounts,
+            "message":
+                "A rHizomE has no beGInning Or enD; "
+                "it is alWays IN the miDDle, between tHings, interbeing, intermeZzO. ThE tree is fiLiatioN, "
+                "but the rhizome is alliance, uniquelY alliance. "
+                "The tree imposes the verb \"to be\" but the fabric of the rhizome is the conJUNction, "
+                "\"AnD ... and ...and...\""
+                "THis conJunction carriEs enouGh force to shaKe and uproot the verb \"to be.\" "
+                "Where are You goIng? Where are you coMing from? What are you heading for? "
+                "These are totally useless questions.\n\n- 'Mille Plateaux', Gilles Deleuze & Felix Guattari\n\n\""
+                "Hyperconnect the world\""
+        }
+    }
+
+    with open(genesis_path, "w") as f:
+        json.dump(genesis_data, f)
+
+
+def get_peer_info(conf_path_list: list, order: int = 0) -> dict:
+    """Get peer information"""
+    target_peer_conf_path = conf_path_list[order]
+
+    with open(target_peer_conf_path) as f:
+        peer_info = json.load(f)
+
+    return peer_info
+
+
+def get_genesis_data(conf_path_list: list):
+    """Get genesis data which is stored at first peer info"""
+    if not conf_path_list:
+        raise RuntimeError()
+
+    peer_info = get_peer_info(conf_path_list=conf_path_list, order=0)
+    genesis_path = peer_info["CHANNEL_OPTION"]["channel_0"]["genesis_data_path"]
+
+    with open(genesis_path) as f:
+        loaded_genesis_data = json.load(f)
+
+    return loaded_genesis_data
+
+
+def _generate_peer_conf_path_list(temporary_path, peer_count: int, channel_list, wallet_password: str = "password") -> tuple:
+    """Generate config for one peer
+
+    It must be used as a wrapped function, due to the random-generated config path.
+    TODO: This function would be out-of-dated, due to features related to remove channel_manage_data.json
+
+    Args:
+        temporary_path: Do not supply this.
+        peer_count (int): Value how many config peers are created
+        wallet_password (str): Password of wallet
+        channel_list: Iterable contains channel names. Each peer contains those channels.
+
+    Returns tuple that contains below:
+        peer_conf_path_list (list): Paths of configure file
+        channel_manage_data_path (str): Channel manage data path
+    """
+    accounts_in_genesis = [
+        {
+            "name": "god",
+            "address": "hx0000000000000000000000000000000000000000",
+            "balance": "0x2961ffa20dd47f5c4700000"
+        },
+        {
+            "name": "treasury",
+            "address": "hx1000000000000000000000000000000000000000",
+            "balance": "0x0"
+        }
+    ]
+    genesis_path = os.path.join(temporary_path, "genesis_test.json")
+    chann_manage_path = os.path.join(temporary_path, "channel_manage_data.json")
+
+    peer_conf_path_list = []
+
+    for peer_order in range(peer_count):
+        # MAKE KEY FILES
+        wallet_key_path = os.path.join(temporary_path, f"keystore_{peer_order}.json")
+        account_addr = generate_addr(wallet_key_path, password="password")
+
+        # MAKE GENESIS FILE
+        accounts_in_genesis.append({
+            "name": f"atheist_{peer_order}",
+            "address": account_addr,
+            "balance": "0x2961ffa20dd47f5c4700000" if peer_order == 0 else "0x0"
+        })
+
+        # PEER CONFIG SETTING
+        channel_setting: dict = _get_channel_setting()
+        if peer_order == 0:
+            channel_setting["genesis_data_path"] = genesis_path
+
+        peer_config = {
+            "LOOPCHAIN_DEFAULT_CHANNEL": channel_list[0],
+            "CHANNEL_OPTION": {channel_name: channel_setting for channel_name in channel_list},
+            "PRIVATE_PATH": wallet_key_path,
+            "PRIVATE_PASSWORD": wallet_password,
+            "RUN_ICON_IN_LAUNCHER": True,
+            "ALLOW_MAKE_EMPTY_BLOCK": False,
+            "PORT_PEER": 7100 + (peer_order * 100),
+            "PEER_ORDER": peer_order + 1,
+            "PEER_ID": account_addr,
+            "LOOPCHAIN_DEVELOP_LOG_LEVEL": "INFO",
+            "DEFAULT_STORAGE_PATH": os.path.join(temporary_path, ".storage_integration_test"),
+            "CHANNEL_MANAGE_DATA_PATH": chann_manage_path
+        }
+
+        # WRITE EACH PEER CONFIG
+        config_path = os.path.join(temporary_path, f"conf_{peer_order}.json")
+        with open(config_path, "w") as f:
+            json.dump(peer_config, f)
+        peer_conf_path_list.append(config_path)
+
+    generate_genesis_file(genesis_path=genesis_path, accounts=accounts_in_genesis)
+    generate_channel_manage_data(channel_manage_data_path=chann_manage_path, config_path_list=peer_conf_path_list)
+
+    return peer_conf_path_list, chann_manage_path
+
+
+@pytest.fixture
+def generate_peer_conf_path_list(tmp_path_factory):
+    """Generate list of peer config file paths
+
+    This is for 'tests_for_fixtures', which tests fixtures of integration test.
+    Whenever it called, it creates brand-new config path list.
+    """
+    tmp_path = tmp_path_factory.mktemp("function_scope_test")
+    return partial(_generate_peer_conf_path_list, temporary_path=tmp_path)
+
+
+@pytest.fixture(scope="class")
+def generate_peer_conf_path_list_extended(tmp_path_factory):
+    """Generate list of peer config file paths
+
+    Aimed for long-running processes in test,
+    this fixture is activated when the scope is valid and, and processes are terminated when the scope is end.
+    """
+    tmp_path = tmp_path_factory.mktemp("widen_scope_test")
+    return partial(_generate_peer_conf_path_list, temporary_path=tmp_path)
+
+
+class Loopchain(ProcessStarter):
+    """Loopchain process starter
+
+    When the stdout line count reaches to end_line, Loopchain process assume that the process fail to run.
+    """
+    args = None
+    pattern = None
+    end_line: int = None
+
+    def filter_lines(self, lines):
+        return itertools.islice(lines, Loopchain.end_line)

--- a/testcase/integration/test_for_fixtures.py
+++ b/testcase/integration/test_for_fixtures.py
@@ -18,7 +18,7 @@ class TestLoopchainBasic:
     ]
 
     def test_generate_wallet_addr(self, tmp_path):
-        """Check that wallet generator has no issues in making account"""
+        """Check that wallet generator has no issues in making accounts"""
         wallet_key_path = os.path.join(tmp_path, "test_keystore.key")
         account_addr = conftest.generate_addr(wallet_key_path=wallet_key_path, password="password")
 
@@ -32,9 +32,7 @@ class TestLoopchainBasic:
 
     @pytest.mark.parametrize("channel_list", channel_name_list)
     def test_generate_peer_conf_has_valid_channel_names(self, generate_peer_conf_path_list, channel_list):
-        """Check that each peer config has desired channel name
-
-        Check that all configs have correct channel names that are previously supplied"""
+        """Check that all peer configs have channel name given by list"""
         path_list, _ = generate_peer_conf_path_list(peer_count=1, channel_list=channel_list)
         for each_conf_path in path_list:
             with open(each_conf_path) as f:
@@ -43,7 +41,7 @@ class TestLoopchainBasic:
             assert list(conf_content["CHANNEL_OPTION"].keys()) == channel_list
 
     def test_generate_peer_conf_has_valid_peer_id(self, generate_peer_conf_path_list):
-        """Ensure that its wallet can derive its peer id"""
+        """Check that all paths contains valid wallets and peer id"""
         path_list, _ = generate_peer_conf_path_list(peer_count=5, channel_list=["channel_no_name"])
 
         for each_conf_path in path_list:
@@ -57,15 +55,16 @@ class TestLoopchainBasic:
 
     @pytest.mark.parametrize("peer_count", [1, 2, 3, 4, 5])
     def test_generate_config_contains_desired_peer_count(self, generate_peer_conf_path_list, peer_count):
-        """Check that desired number of peer configures have been made"""
+        """Test that desired number of peer configures have been successfully made"""
         path_list, _ = generate_peer_conf_path_list(peer_count=peer_count, channel_list=["just_test"])
 
         assert len(path_list) == peer_count
 
     def test_run_loopchain_with_no_exception(self, xprocess, request, generate_peer_conf_path_list):
-        """Test single loopchain to check running without exception
+        """Test that loopchain runs without any exception
 
-        Try to catch 'raise' keyword from stdout.
+        :raise: AssertionError if error pattern catched while running.
+        :raise: RuntimeError if no error pattern catched while running, which means successfully initialized.
         """
         channel_count = int(request.config.getoption("--channel-count"))
         channel_list = [f"channel_{i}" for i in range(channel_count)]

--- a/testcase/integration/test_for_fixtures.py
+++ b/testcase/integration/test_for_fixtures.py
@@ -1,0 +1,90 @@
+import json
+import os
+import time
+
+import pytest
+from iconsdk.wallet.wallet import KeyWallet
+
+from . import conftest
+from .conftest import Loopchain
+
+
+# @pytest.mark.skip
+class TestLoopchainBasic:
+    channel_name_list = [
+        ["test_one_channel"],
+        ["ICON_DEX", "DEX_ICON"],
+        ["ICON_DEX", "NOCI", "THIRD_cHaNnEl"],
+    ]
+
+    def test_generate_wallet_addr(self, tmp_path):
+        """Check that wallet generator has no issues in making account"""
+        wallet_key_path = os.path.join(tmp_path, "test_keystore.key")
+        account_addr = conftest.generate_addr(wallet_key_path=wallet_key_path, password="password")
+
+        with open(wallet_key_path) as f:
+            content = json.load(f)
+
+        print("KEY_CONTENT: ", content)
+        print("accdr: ", account_addr)
+        assert isinstance(content, dict)
+        assert account_addr.startswith("hx")
+
+    @pytest.mark.parametrize("channel_list", channel_name_list)
+    def test_generate_peer_conf_has_valid_channel_names(self, generate_peer_conf_path_list, channel_list):
+        """Check that each peer config has desired channel name
+
+        Check that all configs have correct channel names that are previously supplied"""
+        path_list, _ = generate_peer_conf_path_list(peer_count=1, channel_list=channel_list)
+        for each_conf_path in path_list:
+            with open(each_conf_path) as f:
+                conf_content = json.load(f)
+
+            assert list(conf_content["CHANNEL_OPTION"].keys()) == channel_list
+
+    def test_generate_peer_conf_has_valid_peer_id(self, generate_peer_conf_path_list):
+        """Ensure that its wallet can derive its peer id"""
+        path_list, _ = generate_peer_conf_path_list(peer_count=5, channel_list=["channel_no_name"])
+
+        for each_conf_path in path_list:
+            with open(each_conf_path) as f:
+                conf_content = json.load(f)
+
+            key_path = conf_content["PRIVATE_PATH"]
+            key_pass = conf_content["PRIVATE_PASSWORD"]
+            addr = conf_content["PEER_ID"]
+            assert addr == KeyWallet.load(key_path, key_pass).get_address()
+
+    @pytest.mark.parametrize("peer_count", [1, 2, 3, 4, 5])
+    def test_generate_config_contains_desired_peer_count(self, generate_peer_conf_path_list, peer_count):
+        """Check that desired number of peer configures have been made"""
+        path_list, _ = generate_peer_conf_path_list(peer_count=peer_count, channel_list=["just_test"])
+
+        assert len(path_list) == peer_count
+
+    def test_run_loopchain_with_no_exception(self, xprocess, request, generate_peer_conf_path_list):
+        """Test single loopchain to check running without exception
+
+        Try to catch 'raise' keyword from stdout.
+        """
+        channel_count = int(request.config.getoption("--channel-count"))
+        channel_list = [f"channel_{i}" for i in range(channel_count)]
+        conf_path_list, _ = generate_peer_conf_path_list(channel_list=channel_list, peer_count=1)
+        each_peer_conf = conf_path_list[0]
+
+        Loopchain.pattern = "Errno|[Ee]rror|refused|raise"
+        Loopchain.args = ["loop", "peer", "-d", "-o", each_peer_conf]
+        Loopchain.end_line = 80 * channel_count
+        proc_name = "Exception_detective"
+
+        with pytest.raises(RuntimeError):
+            try:
+                xprocess.ensure(proc_name, Loopchain)
+                raise AssertionError("Exception Found!")
+            except RuntimeError as e:
+                print("All green. No exception found until timeout.")
+                raise e
+            finally:
+                proc_info = xprocess.getinfo(proc_name)
+                proc_info.terminate()
+                time.sleep(3)

--- a/testcase/integration/test_for_fixtures.py
+++ b/testcase/integration/test_for_fixtures.py
@@ -77,14 +77,12 @@ class TestLoopchainBasic:
         Loopchain.end_line = 80 * channel_count
         proc_name = "Exception_detective"
 
-        with pytest.raises(RuntimeError):
-            try:
+        try:
+            with pytest.raises(RuntimeError):
                 xprocess.ensure(proc_name, Loopchain)
                 raise AssertionError("Exception Found!")
-            except RuntimeError as e:
-                print("All green. No exception found until timeout.")
-                raise e
-            finally:
-                proc_info = xprocess.getinfo(proc_name)
-                proc_info.terminate()
-                time.sleep(3)
+            print("All green. No exception found until timeout.")
+        finally:
+            proc_info = xprocess.getinfo(proc_name)
+            proc_info.terminate()
+            time.sleep(3)

--- a/testcase/integration/test_integration.py
+++ b/testcase/integration/test_integration.py
@@ -1,0 +1,282 @@
+import binascii
+import random
+import time
+
+import pytest
+from iconsdk.builder.transaction_builder import MessageTransactionBuilder
+from iconsdk.icon_service import IconService
+from iconsdk.providers.http_provider import HTTPProvider
+from iconsdk.signed_transaction import SignedTransaction
+from iconsdk.wallet.wallet import KeyWallet
+from loopchain.blockchain.types import VarBytes
+
+from loopchain import conf
+from loopchain import utils
+from . import conftest
+from .conftest import Loopchain
+
+# Global variables
+peer_conf_path_list = []  # Peer config file path list. Needed to query peers' information.
+genesis_data: dict = None  # Genesis tx content. Compared with tx in genesis block.
+
+
+@pytest.fixture(scope="class", autouse=True)
+def loopchain_proc(xprocess, request, generate_peer_conf_path_list_extended):
+    """Set up loopchain launcher for integration test"""
+    # Define test environment
+    global peer_conf_path_list
+    global genesis_data
+    proc_info_list = []  # Loopchain process info. Needed to tear down processes.
+
+    peer_type = request.config.getoption("--peer-type")
+    peer_count = int(request.config.getoption("--peer-count"))
+    channel_count = int(request.config.getoption("--channel-count"))
+    channel_list = [f"channel_{i}" for i in range(channel_count)]
+    print(f"\n*--- Test env:\n Peer Type: {peer_type}, Peer Count: {peer_count}, Channel Count: {channel_count}")
+
+    Loopchain.pattern = f"BroadcastScheduler process\(channel_{channel_count - 1}\) start"
+    Loopchain.end_line = 80 * peer_count * channel_count
+
+    # Generate configure files. Run only one time at the beginning of the test.
+    print("*--- Generate peer configure path list...")
+    peer_conf_path_list, channel_manage_data_path = \
+        generate_peer_conf_path_list_extended(peer_count=peer_count, channel_list=channel_list)
+    print("> peer_conf_path: ", peer_conf_path_list)
+    print("> channel_manage_data_path: ", channel_manage_data_path)
+
+    genesis_data = conftest.get_genesis_data(conf_path_list=peer_conf_path_list)
+
+    # Run Each peer
+    for peer_order in range(peer_count):
+        peer_conf_path = peer_conf_path_list[peer_order]
+        Loopchain.args = ["loop", peer_type, "-d", "-o", peer_conf_path]
+        proc_name = f"peer{peer_order}"
+
+        print(f"==========PEER_{peer_order} READY TO START ==========")
+        xprocess.ensure(proc_name, Loopchain)
+
+        # Store process infomation for terminate processes at the end of the test
+        proc_info = xprocess.getinfo(proc_name)
+        proc_info_list.append(proc_info)
+
+    print(f"==========ALL GREEN ==========")
+    time.sleep(0.5 * peer_count * channel_count)
+
+    yield True
+
+    # Executed after this fixture's scope ends.
+    for proc_info in proc_info_list:
+        proc_info.terminate()
+
+    time.sleep(3)  # For additional tests, need a moment to cool down.
+
+
+class TestLoopchain:
+    sent_tx_data = {}  # Sent tx data. Needed to be compared whether it equals with the queried one.
+    tx_hash_by_channel = {}  # Tx hashes. It collects return values of 'send_transaction'.
+
+    # @pytest.mark.skip
+    def test_health_check_before_test(self, request):
+        """Health check before test starts
+
+        Test steps:
+            1. Get genesis local file which is created when the test starts.
+            2. Get rich account's balance (God is not used. Generally third one.)
+            3. Get balance from 'All channels of All peers'.
+            4. Compare original balance with queried one.
+
+        Assertion Tests:
+            1. Queried balance == Expected balance
+            2. All queried balance has same value
+        """
+        global genesis_data
+        print("Genesis data: ", genesis_data)
+
+        peer_count = int(request.config.getoption("--peer-count"))
+        channel_count = int(request.config.getoption("--channel-count"))
+
+        genesis_node = genesis_data["transaction_data"]["accounts"][2]
+        target_account = genesis_node["address"]
+        expected_balance = int(genesis_node["balance"], 16)
+        print("Address of billionaire account: ", target_account)
+
+        querried_balance_list = []
+
+        for peer_order in range(peer_count):
+            port = 9000 + (peer_order * 100)
+
+            for channel_num in range(channel_count):
+                url = utils.normalize_request_url(str(port), conf.ApiVersion.v3, f"channel_{channel_num}")
+                print("Req url: ", url)
+                icon_service = IconService(HTTPProvider(url))
+                queried_balance = icon_service.get_balance(target_account)
+                print("Queried balance: ", queried_balance)
+
+                assert queried_balance == expected_balance
+                querried_balance_list.append(queried_balance)
+                time.sleep(0.5)
+
+        print("Balance all: ", querried_balance_list)
+        assert len(set(querried_balance_list)) == 1
+
+    # @pytest.mark.skip
+    def test_compare_genesis_tx_with_initial_data(self):
+        """Test that the first peer is initialized with given genesis data
+
+        Similar to 'test_health_check_before_test',
+        but it tries to catch all critical values of genesis tx in order to ensure test reliablity.
+
+        # TODO: Could be changed or enhanced when the block version 0.3 is applied.
+
+        Test steps:
+            1. Get genesis tx
+            2. Query genesis tx
+            3. Compare two Txs
+        """
+        global genesis_data
+        expected_data = genesis_data["transaction_data"]
+        print("EXPECTED tx_data: ", expected_data)
+
+        # TODO: iconsdk does not provide channel select on current version (1.0.9).
+        url = utils.normalize_request_url("9000", conf.ApiVersion.v3, "channel_0")
+        icon_service = IconService(HTTPProvider(url))
+        block = icon_service.get_block(0)
+        tx_list = block["confirmed_transaction_list"][0]
+        print("tx_list: ", tx_list)
+
+        assert tx_list["message"] == expected_data["message"]
+        assert tx_list["nid"] == expected_data["nid"]
+        assert tx_list["accounts"] == expected_data["accounts"]
+
+    @pytest.mark.skip(reason="Could be a redundant test")
+    def test_all_peers_running_with_synced_data(self, request):
+        """Test that all peers are alive"""
+        peer_count = int(request.config.getoption("--peer-count"))
+
+        for peer_order in range(1, peer_count):
+            port = 9000 + (peer_order * 100)
+            url = utils.normalize_request_url(str(port), conf.ApiVersion.v3, "channel_0")
+            icon_service = IconService(HTTPProvider(url))
+            block = icon_service.get_block("latest")
+
+            print("REQ url: ", url)
+            print("RES block: ", block)
+
+            assert "error" not in block
+
+    # @pytest.mark.skip
+    def test_send_tx_message(self, request):
+        """Test for 'send_transaction'
+
+        Note:
+            Uses Message Type Transaction.
+            From address is equal to To address.
+            Interval await time is essential, due to consensus completion and different tx hashes between channels.
+
+        Test steps:
+            1. Get peer info from first peer
+            2. Extract key and password and make wallet
+            3. Build message transaction and sign it
+            4. Send Tx to first channel.
+            5. Await consensus time(currently 0.5 * <<Number of peers>> 'sec')
+            6. Repeat from '3'
+
+        Assertion Test:
+            1. Check that return value of send_transaction has valid tx hash format.
+        """
+        global peer_conf_path_list
+
+        channel_count = int(request.config.getoption("--channel-count"))
+
+        from_peer = conftest.get_peer_info(conf_path_list=peer_conf_path_list, order=0)
+        key_path = from_peer["PRIVATE_PATH"]
+        key_pass = from_peer["PRIVATE_PASSWORD"]
+        wallet = KeyWallet.load(key_path, key_pass)
+
+        for channel_order in range(channel_count):
+            # Create message
+            byte_msg = f"test_msg on {random.randint(0, 44444)}".encode("utf-8")
+            msg = VarBytes(byte_msg).hex_0x()
+
+            # Address
+            from_to_address = wallet.get_address()
+
+            # Store tx data to compare with queried one later.
+            channel_name = f"channel_{channel_order}"
+            TestLoopchain.sent_tx_data[channel_name] = {
+                "from": from_to_address,
+                "to": from_to_address,
+                "msg": msg
+            }
+
+            # Build transaction and sign it with wallet
+            transaction_data = {
+                "from": from_to_address,
+                "to": from_to_address,
+                "step_limit": 100000000,
+                "nid": 3,
+                "nonce": 100,
+                "data": msg,
+            }
+            transaction = MessageTransactionBuilder().from_dict(transaction_data).build()
+            signed_transaction = SignedTransaction(transaction, wallet)
+
+            # Send tx
+            url = utils.normalize_request_url("9000", conf.ApiVersion.v3, channel_name)
+            print("Req url: ", url)
+            icon_service = IconService(HTTPProvider(url))
+            tx_hash = icon_service.send_transaction(signed_transaction)
+            print("Tx hash: ", tx_hash)
+
+            assert tx_hash.startswith("0x")
+            TestLoopchain.tx_hash_by_channel[channel_name] = tx_hash
+
+            await_sec = 0.5 * len(peer_conf_path_list)
+            print(f"Await consensus...({await_sec})")
+            time.sleep(await_sec)
+
+        print("ALL TXs by channel: ", TestLoopchain.tx_hash_by_channel)
+        final_await_sec = 1 * channel_count
+        print(f"Await consensus final...({final_await_sec})")
+        time.sleep(final_await_sec)
+
+    # @pytest.mark.skip
+    def test_sent_tx_is_synced(self, request):
+        """Following test of 'test_send_tx_message'
+
+        Check that send_transaction is successfully completed.
+
+        Test steps:
+            1. Get tx_hash from previous test
+            2. Query tx_hash to first channel
+            3. Compare queried tx with original data
+            4. Repeat until the channel order reaches to the end
+
+        Assertion Tests:
+            Check Tx values below
+            1. From address
+            2. To address
+            3. Data (message)
+        """
+        print("sent_tx_data: ", TestLoopchain.sent_tx_data)
+
+        peer_count = int(request.config.getoption("--peer-count"))
+        channel_count = int(request.config.getoption("--channel-count"))
+
+        for peer_order in range(peer_count):
+            port = 9000 + (peer_order * 100)
+            for channel_order in range(channel_count):
+                channel_name = f"channel_{channel_order}"
+                url = utils.normalize_request_url(str(port), conf.ApiVersion.v3, channel_name)
+                print("Req url: ", url)
+                icon_service = IconService(HTTPProvider(url))
+                tx_hash = TestLoopchain.tx_hash_by_channel[channel_name]
+                print("Tx hash to be queried: ", tx_hash)
+                queried_tx = icon_service.get_transaction(tx_hash)
+                print("Tx result: ", queried_tx)
+
+                assert queried_tx["from"] == TestLoopchain.sent_tx_data[channel_name]["from"]
+                assert queried_tx["to"] == TestLoopchain.sent_tx_data[channel_name]["to"]
+                assert queried_tx["data"] == TestLoopchain.sent_tx_data[channel_name]["msg"]
+
+                time.sleep(0.5)


### PR DESCRIPTION
# Test steps:
To run tests, follow step below...
1. clone the repository and make virtualenv 
2. `$ make develop`
3. `$ pytest testcase/integration [-v] [options]`
> **_NOTE_**: Possible [options] are:
> - `--peer-count=[int]`: execute test with [int] peers
> - `--channel-count=[int]`: execute test with [int] channels

**_... or you can simply run tests by `$ make test`_**

# Test check list
This test tries to...
- Run loopchain launcher and check stdout lines to find any exception raised
- Check all peers and channels are ready to receive transactions 
- Send transaction and get valid tx_hash
- Check Sent transactions are successfully synced between peers (also channels)

# Test script
- `conftest.py`: contains common test fixture and helper for making loopchain config.
- `test_for_fixtures.py`: contains basic tests to be run before integration test.
- `test_integration.py`: contains tests for loopchain integration scenario. 

# Note
- Ensure that there are no loopchain-related process is running!