### PR TITLE
[LC-431] Fix some bugs about the leader complaint.

### DIFF
--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -77,7 +77,7 @@ class Epoch:
         util.logger.debug(f"Set Epoch leader height({self.height}) leader_id({leader_id})")
         self.leader_id = leader_id
         if complained and leader_id == ChannelProperty().peer_id:
-            self.complained_result = self.complain_result()
+            self.complained_result = complained
         else:
             self.complained_result = None
 

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -185,6 +185,7 @@ class ConsensusSiever(ConsensusBase):
                                  f"next_leader({next_leader.hex_hx()}) "
                                  f"peer_id({ChannelProperty().peer_id})")
                 ObjectManager().channel_service.reset_leader(next_leader.hex_hx())
+                ObjectManager().channel_service.turn_on_leader_complain_timer()
             else:
                 self._block_manager.epoch = Epoch.new_epoch(next_leader.hex_hx())
                 if not conf.ALLOW_MAKE_EMPTY_BLOCK:


### PR DESCRIPTION
- The last leader doesn't turn a complaint timer on after type is turned to peer.
- Sometimes the `leader complaint block` doesn't be built.