### PR TITLE
[LC-407] remove PUBLIC_PATH in configure_default and remove from_channel in SignVerifier

### DIFF
--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -333,12 +333,9 @@ class ChannelService:
 
     async def __init_peer_auth(self):
         try:
-            node_key: bytes = await StubCollection().peer_stub.async_task().get_node_key(ChannelProperty().name)
+            node_key: bytes = await StubCollection().peer_stub.async_task().get_node_key()
             self.__peer_auth = Signer.from_prikey(node_key)
-        except KeyError:
-            self.__peer_auth = Signer.from_channel(ChannelProperty().name)
         except Exception as e:
-            logging.exception(f"peer auth init fail cause : {e}")
             utils.exit_and_msg(f"peer auth init fail cause : {e}")
 
     def __init_block_manager(self):

--- a/loopchain/configure_default.py
+++ b/loopchain/configure_default.py
@@ -366,7 +366,6 @@ CHANNEL_OPTION = {
     }
 }
 
-PUBLIC_PATH = os.path.join(LOOPCHAIN_ROOT_PATH, 'resources/default_pki/public.der')
 PRIVATE_PATH = os.path.join(LOOPCHAIN_ROOT_PATH, 'resources/default_pki/private.der')
 PRIVATE_PASSWORD = None
 

--- a/loopchain/crypto/signature.py
+++ b/loopchain/crypto/signature.py
@@ -14,12 +14,13 @@
 """ A class for icx authorization of Peer"""
 
 import binascii
-import getpass
 import hashlib
 import logging
 from typing import Union, Type, TypeVar
+
 from secp256k1 import Base, ALL_FLAGS
 from secp256k1 import PrivateKey, PublicKey
+
 from loopchain.crypto.cert_serializers import DerSerializer, PemSerializer
 
 T = TypeVar('T', bound='SignVerifier')
@@ -75,18 +76,6 @@ class SignVerifier:
         verifier = SignVerifier()
         verifier.address = address
         return verifier
-
-    @classmethod
-    def from_channel(cls: Type[T], channel: str) -> T:
-        from loopchain import configure as conf
-
-        if 'public_path' in conf.CHANNEL_OPTION[channel]:
-            logging.warning(f"This setting(public_path) will be deprecated soon. "
-                            f"Please refer to the key configuration guide.")
-            public_file = conf.CHANNEL_OPTION[channel]['public_path']
-        else:
-            public_file = conf.PUBLIC_PATH
-        return cls.from_pubkey_file(public_file)
 
     @classmethod
     def from_pubkey_file(cls: Type[T], pubkey_file: str) -> T:
@@ -160,28 +149,6 @@ class Signer(SignVerifier):
     @classmethod
     def from_address(cls: Type[T], address: str) -> T:
         raise TypeError("Cannot create `Signer` from address")
-
-    @classmethod
-    def from_channel(cls: Type[T], channel: str) -> T:
-        from loopchain import configure as conf
-
-        if 'private_path' in conf.CHANNEL_OPTION[channel]:
-            logging.warning(f"This setting(private_path) will be deprecated soon. "
-                            f"Please refer to the key configuration guide.")
-            prikey_file = conf.CHANNEL_OPTION[channel]['private_path']
-        else:
-            prikey_file = conf.PRIVATE_PATH
-
-        if 'private_password' in conf.CHANNEL_OPTION[channel]:
-            logging.warning(f"This setting(private_password) will be deprecated soon. "
-                            f"Please refer to the key configuration guide.")
-            password = conf.CHANNEL_OPTION[channel]['private_password']
-        elif conf.PRIVATE_PASSWORD:
-            password = conf.PRIVATE_PASSWORD
-        else:
-            # created the private key file from tbears.
-            password = getpass.getpass(f"Input your keystore password for channel({channel}): ")
-        return cls.from_prikey_file(prikey_file, password)
 
     @classmethod
     def from_pubkey(cls: Type[T], pubkey: bytes) -> T:

--- a/loopchain/peer/peer_inner_service.py
+++ b/loopchain/peer/peer_inner_service.py
@@ -50,8 +50,8 @@ class PeerInnerTask:
         }
 
     @message_queue_task
-    async def get_node_key(self, channel_name) -> bytes:
-        return self._peer_service.node_keys[channel_name]
+    async def get_node_key(self) -> bytes:
+        return self._peer_service.node_key
 
     # FIXME : not used?
     @message_queue_task

--- a/loopchain/peer/peer_service.py
+++ b/loopchain/peer/peer_service.py
@@ -15,6 +15,7 @@
 It has secure outer service for p2p consensus and status monitoring.
 And also has insecure inner service for inner process modules."""
 
+import getpass
 import multiprocessing
 import signal
 import timeit
@@ -36,17 +37,14 @@ from loopchain.utils.message_queue import StubCollection
 
 
 class PeerService:
-    """Peer Service 의 main Class
-    outer 와 inner gRPC 인터페이스를 가진다.
-    서비스 루프 및 공통 요소는 commonservice 를 통해서 처리한다.
-    channel 관련 instance 는 channel manager 를 통해서 관리한다.
-    """
+    """Main class of peer service having outer & inner gRPC interface
 
+    """
     def __init__(self, radio_station_target=None, node_type=None):
         """Peer는 Radio Station 에 접속하여 leader 및 다른 Peer에 대한 접속 정보를 전달 받는다.
 
-        :param radio_station_ip: RS IP
-        :param radio_station_port: RS Port
+        :param radio_station_target: IP:Port of Radio Station
+        :param node_type: node type
         :return:
         """
         node_type = node_type or conf.NodeType.CommunityNode
@@ -57,106 +55,103 @@ class PeerService:
         utils.logger.spam(f"Your Peer Service runs on debugging MODE!")
         utils.logger.spam(f"You can see many terrible garbage logs just for debugging, DO U Really want it?")
 
-        self.__node_type = node_type
+        self._node_type = node_type
 
-        self.__radio_station_target = radio_station_target
-        logging.info("Set Radio Station target is " + self.__radio_station_target)
+        self._radio_station_target = radio_station_target
+        logging.info("Set Radio Station target is " + self._radio_station_target)
 
-        self.__radio_station_stub = None
-        self.__peer_id = None
+        self._radio_station_stub = None
+        self._peer_id = None
+        self._node_key = bytes()
         self.p2p_outer_server: grpc.Server = None
-        self.__channel_infos = None
-
-        self.__rest_service = None
-        self.__rest_proxy_server = None
+        self._channel_infos = None
 
         # peer status cache for channel
         self.status_cache = {}  # {channel:status}
 
-        self.__score = None
-        self.__peer_target = None
-        self.__rest_target = None
-        self.__peer_port = 0
+        self._peer_target = None
+        self._rest_target = None
+        self._peer_port = 0
 
         # gRPC service for Peer
-        self.__inner_service: PeerInnerService = None
-        self.__outer_service: PeerOuterService = None
-        self.__channel_services = {}
+        self._inner_service: PeerInnerService = None
+        self._outer_service: PeerOuterService = None
 
-        self.__node_keys: dict = {}
+        self._channel_services = {}
+        self._rest_service = None
 
         ObjectManager().peer_service = self
 
     @property
     def inner_service(self):
-        return self.__inner_service
+        return self._inner_service
 
     @property
     def outer_service(self):
-        return self.__outer_service
+        return self._outer_service
 
     @property
     def peer_target(self):
-        return self.__peer_target
+        return self._peer_target
 
     @property
     def rest_target(self):
-        return self.__rest_target
+        return self._rest_target
 
     @property
     def channel_infos(self):
-        return self.__channel_infos
+        return self._channel_infos
 
     @property
     def node_type(self):
-        return self.__node_type
+        return self._node_type
 
     @property
     def radio_station_target(self):
-        return self.__radio_station_target
+        return self._radio_station_target
 
     @property
     def stub_to_radiostation(self):
-        if self.__radio_station_stub is None:
+        if self._radio_station_stub is None:
             if self.is_support_node_function(conf.NodeFunction.Vote):
                 if conf.ENABLE_REP_RADIO_STATION:
-                    self.__radio_station_stub = StubManager.get_stub_manager_to_server(
-                        self.__radio_station_target,
+                    self._radio_station_stub = StubManager.get_stub_manager_to_server(
+                        self._radio_station_target,
                         loopchain_pb2_grpc.RadioStationStub,
                         conf.CONNECTION_RETRY_TIMEOUT_TO_RS,
                         ssl_auth_type=conf.GRPC_SSL_TYPE)
                 else:
-                    self.__radio_station_stub = None
+                    self._radio_station_stub = None
             else:
-                self.__radio_station_stub = RestStubManager(self.__radio_station_target)
+                self._radio_station_stub = RestStubManager(self._radio_station_target)
 
-        return self.__radio_station_stub
+        return self._radio_station_stub
 
     @property
     def peer_port(self):
-        return self.__peer_port
+        return self._peer_port
 
     @property
     def peer_id(self):
-        return self.__peer_id
+        return self._peer_id
 
     @property
-    def node_keys(self):
-        return self.__node_keys
+    def node_key(self):
+        return self._node_key
 
     def p2p_server_stop(self):
         self.p2p_outer_server.stop(None)
 
-    def __get_channel_infos(self):
+    def _get_channel_infos(self):
         # util.logger.spam(f"__get_channel_infos:node_type::{self.__node_type}")
         if self.is_support_node_function(conf.NodeFunction.Vote):
             if conf.ENABLE_REP_RADIO_STATION:
                 response = self.stub_to_radiostation.call_in_times(
                     method_name="GetChannelInfos",
                     message=loopchain_pb2.GetChannelInfosRequest(
-                        peer_id=self.__peer_id,
-                        peer_target=self.__peer_target,
-                        group_id=self.__peer_id),
+                        peer_id=self._peer_id,
+                        peer_target=self._peer_target,
+                        group_id=self._peer_id),
                     retry_times=conf.CONNECTION_RETRY_TIMES_TO_RS,
                     is_stub_reuse=False,
                     timeout=conf.CONNECTION_TIMEOUT_TO_RS
@@ -175,44 +170,48 @@ class PeerService:
 
         return channels
 
-    def __init_port(self, port):
+    def _init_port(self, port):
         # service 초기화 작업
         target_ip = utils.get_private_ip()
-        self.__peer_target = utils.get_private_ip() + ":" + str(port)
-        self.__peer_port = int(port)
+        self._peer_target = f"{target_ip}:{port}"
+        self._peer_port = int(port)
 
         rest_port = int(port) + conf.PORT_DIFF_REST_SERVICE_CONTAINER
-        self.__rest_target = f"{target_ip}:{rest_port}"
+        self._rest_target = f"{target_ip}:{rest_port}"
 
         logging.info("Start Peer Service at port: " + str(port))
 
-    def __run_rest_services(self, port):
+    def _run_rest_services(self, port):
         if conf.ENABLE_REST_SERVICE and conf.RUN_ICON_IN_LAUNCHER:
             logging.debug(f'Launch Sanic RESTful server. '
                           f'Port = {int(port) + conf.PORT_DIFF_REST_SERVICE_CONTAINER}')
-            self.__rest_service = RestService(int(port))
+            self._rest_service = RestService(int(port))
 
-    def __init_key_by_channel(self):
-        for channel in conf.CHANNEL_OPTION:
-            signer = Signer.from_channel(channel)
-            if channel == conf.LOOPCHAIN_DEFAULT_CHANNEL:
-                self.__make_peer_id(signer.address)
-            self.__node_keys[channel] = signer.private_key.private_key
+    def _init_node_key(self):
+        prikey_file = conf.PRIVATE_PATH
 
-    def __make_peer_id(self, address):
-        self.__peer_id = address
+        if conf.PRIVATE_PASSWORD:
+            password = conf.PRIVATE_PASSWORD
+        else:
+            password = getpass.getpass(f"Input your keystore password: ")
+        signer = Signer.from_prikey_file(prikey_file, password)
+        self._make_peer_id(signer.address)
+        self._node_key = signer.private_key.private_key
+
+    def _make_peer_id(self, address):
+        self._peer_id = address
 
         logger_preset = loggers.get_preset()
         logger_preset.peer_id = self.peer_id
         logger_preset.update_logger()
 
-        logging.info(f"run peer_id : {self.__peer_id}")
+        logging.info(f"run peer_id : {self._peer_id}")
 
     def timer_test_callback_function(self, message):
         logging.debug(f'timer test callback function :: ({message})')
 
     @staticmethod
-    def __get_use_kms():
+    def _get_use_kms():
         if conf.GRPC_SSL_KEY_LOAD_TYPE == conf.KeyLoadType.KMS_LOAD:
             return True
         for value in conf.CHANNEL_OPTION.values():
@@ -220,19 +219,19 @@ class PeerService:
                 return True
         return False
 
-    def __init_kms_helper(self, agent_pin):
-        if self.__get_use_kms():
+    def _init_kms_helper(self, agent_pin):
+        if self._get_use_kms():
             from loopchain.tools.kms_helper import KmsHelper
             KmsHelper().set_agent_pin(agent_pin)
 
-    def __close_kms_helper(self):
-        if self.__get_use_kms():
+    def _close_kms_helper(self):
+        if self._get_use_kms():
             from loopchain.tools.kms_helper import KmsHelper
             KmsHelper().remove_agent_pin()
 
     def run_p2p_server(self):
-        self.p2p_outer_server = GRPCHelper().start_outer_server(str(self.__peer_port))
-        loopchain_pb2_grpc.add_PeerServiceServicer_to_server(self.__outer_service, self.p2p_outer_server)
+        self.p2p_outer_server = GRPCHelper().start_outer_server(str(self._peer_port))
+        loopchain_pb2_grpc.add_PeerServiceServicer_to_server(self._outer_service, self.p2p_outer_server)
 
     def serve(self,
               port,
@@ -254,31 +253,31 @@ class PeerService:
 
         stopwatch_start = timeit.default_timer()
 
-        self.__init_kms_helper(agent_pin)
-        self.__init_port(port)
-        self.__init_key_by_channel()
+        self._init_kms_helper(agent_pin)
+        self._init_port(port)
+        self._init_node_key()
 
         StubCollection().amqp_target = amqp_target
         StubCollection().amqp_key = amqp_key
 
         peer_queue_name = conf.PEER_QUEUE_NAME_FORMAT.format(amqp_key=amqp_key)
-        self.__outer_service = PeerOuterService()
-        self.__inner_service = PeerInnerService(
+        self._outer_service = PeerOuterService()
+        self._inner_service = PeerInnerService(
             amqp_target, peer_queue_name, conf.AMQP_USERNAME, conf.AMQP_PASSWORD, peer_service=self)
 
-        self.__reset_channel_infos()
+        self._reset_channel_infos()
 
-        self.__run_rest_services(port)
+        self._run_rest_services(port)
         self.run_p2p_server()
 
-        self.__close_kms_helper()
+        self._close_kms_helper()
 
         stopwatch_duration = timeit.default_timer() - stopwatch_start
         logging.info(f"Start Peer Service at port: {port} start duration({stopwatch_duration})")
 
         async def _serve():
             await self.ready_tasks()
-            await self.__inner_service.connect(conf.AMQP_CONNECTION_ATTEMPS, conf.AMQP_RETRY_DELAY, exclusive=True)
+            await self._inner_service.connect(conf.AMQP_CONNECTION_ATTEMPS, conf.AMQP_RETRY_DELAY, exclusive=True)
 
             if conf.CHANNEL_BUILTIN:
                 await self.serve_channels()
@@ -288,7 +287,7 @@ class PeerService:
 
             logging.info(f'peer_service: init complete peer: {self.peer_id}')
 
-        loop = self.__inner_service.loop
+        loop = self._inner_service.loop
         loop.create_task(_serve())
         loop.add_signal_handler(signal.SIGINT, self.close)
         loop.add_signal_handler(signal.SIGTERM, self.close)
@@ -303,11 +302,8 @@ class PeerService:
         # Monitor().stop()
 
         logging.info("Peer Service Ended.")
-        if self.__rest_service is not None:
-            self.__rest_service.stop()
-
-        if self.__rest_proxy_server is not None:
-            self.__rest_proxy_server.stop()
+        if self._rest_service is not None:
+            self._rest_service.stop()
 
     def close(self):
         async def _close():
@@ -317,12 +313,12 @@ class PeerService:
             self.p2p_server_stop()
             loop.stop()
 
-        loop = self.__inner_service.loop
+        loop = self._inner_service.loop
         loop.create_task(_close())
 
     async def serve_channels(self):
-        for i, channel_name in enumerate(self.__channel_infos.keys()):
-            score_port = self.__peer_port + conf.PORT_DIFF_SCORE_CONTAINER + conf.PORT_DIFF_BETWEEN_SCORE_CONTAINER * i
+        for i, channel_name in enumerate(self._channel_infos.keys()):
+            score_port = self._peer_port + conf.PORT_DIFF_SCORE_CONTAINER + conf.PORT_DIFF_BETWEEN_SCORE_CONTAINER * i
 
             args = ['python3', '-m', 'loopchain', 'channel']
             args += ['-p', str(score_port)]
@@ -340,31 +336,31 @@ class PeerService:
             channel_stub = StubCollection().channel_stubs[channel_name]
             await channel_stub.async_task().hello()
 
-            self.__channel_services[channel_name] = service
+            self._channel_services[channel_name] = service
 
     async def ready_tasks(self):
         await StubCollection().create_peer_stub()  # for getting status info
 
-        for channel_name, channel_info in self.__channel_infos.items():
+        for channel_name, channel_info in self._channel_infos.items():
             await StubCollection().create_channel_stub(channel_name)
             await StubCollection().create_channel_tx_receiver_stub(channel_name)
 
             await StubCollection().create_icon_score_stub(channel_name)
 
-    def __reset_channel_infos(self):
-        self.__channel_infos = self.__get_channel_infos()
-        if not self.__channel_infos:
+    def _reset_channel_infos(self):
+        self._channel_infos = self._get_channel_infos()
+        if not self._channel_infos:
             utils.exit_and_msg("There is no peer_list, initial network is not allowed without RS!")
 
     async def change_node_type(self, node_type):
-        if self.__node_type.value == node_type:
+        if self._node_type.value == node_type:
             utils.logger.warning(f"Does not change node type because new note type equals current node type")
             return
 
-        self.__node_type = conf.NodeType(node_type)
+        self._node_type = conf.NodeType(node_type)
         self.is_support_node_function = \
             partial(conf.NodeType.is_support_node_function, node_type=node_type)
 
-        self.__radio_station_stub = None
+        self._radio_station_stub = None
 
-        self.__reset_channel_infos()
+        self._reset_channel_infos()

--- a/testcase/unittest/test_transaction.py
+++ b/testcase/unittest/test_transaction.py
@@ -209,7 +209,6 @@ class TestTransaction(unittest.TestCase):
                 "consensus_cert_use": True,
                 "tx_cert_use": True,
                 "key_load_type": conf.KeyLoadType.FILE_LOAD,
-                "public_path": os.path.join(conf.LOOPCHAIN_ROOT_PATH, 'resources/default_certs/cert.pem'),
                 "private_path": os.path.join(conf.LOOPCHAIN_ROOT_PATH, 'resources/default_certs/key.pem'),
                 "private_password": None
             }


### PR DESCRIPTION
As CHANNEL_OPTION does not have PUBLIC_PATH or PRIVATE_PATH anymore, key will be generated based on node configuration. 
- remove from_channel in Signer, SignVerifier
- remove PUBLIC_PATH configuration
- change dunder(__) method or variable to single underscore