### PR TITLE
[LC-455] disable channel_manage_data in IISS configuration

### DIFF
--- a/loopchain/baseservice/peer_manager.py
+++ b/loopchain/baseservice/peer_manager.py
@@ -198,7 +198,7 @@ class PeerManager:
 
         self.peer_list_data.peer_leader = peer.order
 
-    def get_leader_peer(self, is_complain_to_rs=False, is_peer=True) -> PeerInfo:
+    def get_leader_peer(self, is_peer=True) -> PeerInfo:
         """
 
         :return:
@@ -253,7 +253,7 @@ class PeerManager:
         util.logger.spam(f"peer_manager:get_next_leader_peer current_leader_peer_id({current_leader_peer_id})")
 
         if not current_leader_peer_id:
-            leader_peer = self.get_leader_peer(is_complain_to_rs=True)
+            leader_peer = self.get_leader_peer()
         else:
             leader_peer = self.get_peer(current_leader_peer_id)
 

--- a/loopchain/baseservice/rest_stub_manager.py
+++ b/loopchain/baseservice/rest_stub_manager.py
@@ -42,17 +42,17 @@ class RestStubManager:
                 self._http_clients[url] = HTTPClient(url)
 
         self._method_versions = {
-            "GetChannelInfos": conf.ApiVersion.node,
             "GetBlockByHeight": conf.ApiVersion.node,
             "Status": conf.ApiVersion.v1,
-            "GetLastBlock": conf.ApiVersion.v3
+            "GetLastBlock": conf.ApiVersion.v3,
+            "GetReps": conf.ApiVersion.v3
         }
 
         self._method_names = {
-            "GetChannelInfos": "node_getChannelInfos",
             "GetBlockByHeight": "node_getBlockByHeight",
             "Status": "/status/peer/",
-            "GetLastBlock": "icx_getLastBlock"
+            "GetLastBlock": "icx_getLastBlock",
+            "GetReps": "rep_getList"
         }
 
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="RestStubThread")

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -192,7 +192,7 @@ class ChannelService:
     async def init(self, **kwargs):
         """Initialize Channel Service
 
-        :param kwargs: takes (peer_id, peer_port, peer_target, rest_target, rs_target, node_type, score_package)
+        :param kwargs: takes (peer_id, peer_port, peer_target, rest_target, rs_target, node_type)
         within parameters
         :return: None
         """

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -57,7 +57,6 @@ class ChannelService:
         self.__consensus = None
         self.__timer_service = TimerService()
         self.__node_subscriber: NodeSubscriber = None
-        self.__channel_infos: dict = None
 
         loggers.get_preset().channel_name = channel_name
         loggers.get_preset().update_logger()
@@ -129,8 +128,6 @@ class ChannelService:
         async def _serve():
             await StubCollection().create_peer_stub()
 
-            channel_name = ChannelProperty().name
-            self.__channel_infos = (await StubCollection().peer_stub.async_task().get_channel_infos())[channel_name]
             results = await StubCollection().peer_stub.async_task().get_node_info_detail()
             await self.init(**results)
 
@@ -243,7 +240,9 @@ class ChannelService:
             await self.subscribe_to_parent()
 
         self.__state_machine.complete_subscribe()
-        self.turn_on_leader_complain_timer()
+
+        if self.is_support_node_function(conf.NodeFunction.Vote):
+            self.turn_on_leader_complain_timer()
 
     def update_sub_services_properties(self):
         nid = self.__block_manager.get_blockchain().find_nid()
@@ -285,7 +284,11 @@ class ChannelService:
             else:
                 self._load_peers_from_iiss()
         else:
-            await self._load_peers_from_file()
+            if self.is_support_node_function(conf.NodeFunction.Vote):
+                await self._load_peers_from_file()
+            else:
+                await self._load_peers_from_rest_call()
+        self.show_peers()
 
     def _is_role_switched(self) -> bool:
         current_height = self.__block_manager.get_blockchain().block_height
@@ -432,25 +435,30 @@ class ChannelService:
         utils.logger.debug(f"Peer manager have to update with new list.")
         self.__peer_manager.reset_peers(check_status=False)
 
-        for order, rep_info in enumerate(response["result"]["preps"], 1):
-            peer_info = PeerInfo(rep_info["id"], rep_info["id"], rep_info["target"], order=order)
-            self.__peer_manager.add_peer(peer_info)
-        self.show_peers()
+        reps = response["result"]["preps"]
+        self._add_reps(reps)
 
     async def _load_peers_from_file(self):
-        channel_info = await StubCollection().peer_stub.async_task().get_channel_infos()
-        for peer_info in channel_info[ChannelProperty().name]["peers"]:
+        channel_info = utils.load_json_data(conf.CHANNEL_MANAGE_DATA_PATH)
+        reps: list = channel_info[ChannelProperty().name].get("peers")
+        for peer_info in reps:
             self.__peer_manager.add_peer(peer_info)
-        self.show_peers()
+
+    async def _load_peers_from_rest_call(self):
+        response = self.__radio_station_stub.call("GetReps")
+        reps = response.get('rep')
+        self._add_reps(reps)
+
+    def _add_reps(self, reps: list):
+        for order, rep_info in enumerate(reps, 1):
+            peer_info = PeerInfo(rep_info["id"], rep_info["id"], rep_info["target"], order=order)
+            self.__peer_manager.add_peer(peer_info)
 
     def is_support_node_function(self, node_function):
         return conf.NodeType.is_support_node_function(node_function, ChannelProperty().node_type)
 
     def get_channel_option(self) -> dict:
         return conf.CHANNEL_OPTION[ChannelProperty().name]
-
-    def get_channel_infos(self) -> dict:
-        return self.__channel_infos
 
     def get_rep_ids(self) -> list:
         return [ExternalAddress.fromhex_address(peer_id, allow_malformed=True)
@@ -839,7 +847,7 @@ class ChannelService:
             duration = self.__block_manager.epoch.complain_duration
         # utils.logger.spam(
         #     f"start_leader_complain_timer in channel service. ({self.block_manager.epoch.round}/{duration})")
-        if self.state_machine.state not in ("BlockGenerate", "BlockSync", "Watch"):
+        if self.state_machine.state in ("Vote", "LeaderComplain"):
             self.__timer_service.add_timer_convenient(timer_key=TimerService.TIMER_KEY_LEADER_COMPLAIN,
                                                       duration=duration,
                                                       is_repeat=True, callback=self.state_machine.leader_complain)

--- a/loopchain/configure_default.py
+++ b/loopchain/configure_default.py
@@ -48,7 +48,7 @@ class LogOutputType(IntFlag):
 LOOPCHAIN_LOG_LEVEL = os.getenv('LOOPCHAIN_LOG_LEVEL', 'DEBUG')
 LOOPCHAIN_DEVELOP_LOG_LEVEL = "SPAM"
 LOOPCHAIN_OTHER_LOG_LEVEL = "WARNING"
-LOG_FORMAT = "%(asctime)s,%(msecs)03d %(process)d %(thread)d {PEER_ID} {CHANNEL_NAME}{SCORE_PACKAGE} " \
+LOG_FORMAT = "%(asctime)s,%(msecs)03d %(process)d %(thread)d {PEER_ID} {CHANNEL_NAME} " \
              "%(levelname)s %(filename)s(%(lineno)d) %(message)s"
 
 LOG_OUTPUT_TYPE = LogOutputType.console | LogOutputType.file

--- a/loopchain/peer/peer_service.py
+++ b/loopchain/peer/peer_service.py
@@ -35,6 +35,8 @@ from loopchain.tools.grpc_helper import GRPCHelper
 from loopchain.utils import loggers, command_arguments
 from loopchain.utils.message_queue import StubCollection
 
+DEFAULT_SCORE_PACKAGE = 'score/icx'
+
 
 class PeerService:
     """Main class of peer service having outer & inner gRPC interface
@@ -143,7 +145,6 @@ class PeerService:
         self.p2p_outer_server.stop(None)
 
     def _get_channel_infos(self):
-        # util.logger.spam(f"__get_channel_infos:node_type::{self.__node_type}")
         if self.is_support_node_function(conf.NodeFunction.Vote):
             if conf.ENABLE_REP_RADIO_STATION:
                 response = self.stub_to_radiostation.call_in_times(
@@ -156,19 +157,20 @@ class PeerService:
                     is_stub_reuse=False,
                     timeout=conf.CONNECTION_TIMEOUT_TO_RS
                 )
-                # util.logger.spam(f"__get_channel_infos:response::{response}")
 
                 if not response:
                     return None
                 logging.info(f"Connect to channels({utils.pretty_json(response.channel_infos)})")
-                channels = json.loads(response.channel_infos)
+                return json.loads(response.channel_infos)
+            elif not conf.LOAD_PEERS_FROM_IISS:
+                return utils.load_json_data(conf.CHANNEL_MANAGE_DATA_PATH)
             else:
-                channels = utils.load_json_data(conf.CHANNEL_MANAGE_DATA_PATH)
-        else:
-            response = self.stub_to_radiostation.call_in_times(method_name="GetChannelInfos")
-            channels = {channel: value for channel, value in response["channel_infos"].items()}
+                # this is temporary code for legacy support, and will be removed at next release.
+                return {channel: {'score_package': DEFAULT_SCORE_PACKAGE}
+                        for channel in conf.CHANNEL_OPTION}
 
-        return channels
+        return {channel: {'score_package': DEFAULT_SCORE_PACKAGE}
+                for channel in conf.CHANNEL_OPTION}
 
     def _init_port(self, port):
         # service 초기화 작업
@@ -262,7 +264,7 @@ class PeerService:
         self._inner_service = PeerInnerService(
             amqp_target, peer_queue_name, conf.AMQP_USERNAME, conf.AMQP_PASSWORD, peer_service=self)
 
-        self._reset_channel_infos()
+        self._load_channel_infos()
 
         self._run_rest_services(port)
         self.run_p2p_server()
@@ -314,7 +316,7 @@ class PeerService:
         loop.create_task(_close())
 
     async def serve_channels(self):
-        for i, channel_name in enumerate(self._channel_infos.keys()):
+        for i, channel_name in enumerate(conf.CHANNEL_OPTION):
             score_port = self._peer_port + conf.PORT_DIFF_SCORE_CONTAINER + conf.PORT_DIFF_BETWEEN_SCORE_CONTAINER * i
 
             args = ['python3', '-m', 'loopchain', 'channel']
@@ -338,20 +340,18 @@ class PeerService:
     async def ready_tasks(self):
         await StubCollection().create_peer_stub()  # for getting status info
 
-        for channel_name, channel_info in self._channel_infos.items():
+        for channel_name in conf.CHANNEL_OPTION:
             await StubCollection().create_channel_stub(channel_name)
             await StubCollection().create_channel_tx_receiver_stub(channel_name)
 
             await StubCollection().create_icon_score_stub(channel_name)
 
-    def _reset_channel_infos(self):
+    def _load_channel_infos(self):
         self._channel_infos = self._get_channel_infos()
-        if not self._channel_infos:
-            utils.exit_and_msg("There is no peer_list, initial network is not allowed without RS!")
 
     async def change_node_type(self, node_type):
         if self._node_type.value == node_type:
-            utils.logger.warning(f"Does not change node type because new note type equals current node type")
+            utils.logger.warning(f"There's no change in node type.")
             return
 
         self._node_type = conf.NodeType(node_type)
@@ -360,4 +360,4 @@ class PeerService:
 
         self._radio_station_stub = None
 
-        self._reset_channel_infos()
+        self._load_channel_infos()

--- a/loopchain/peer/peer_service.py
+++ b/loopchain/peer/peer_service.py
@@ -162,12 +162,12 @@ class PeerService:
                     return None
                 logging.info(f"Connect to channels({utils.pretty_json(response.channel_infos)})")
                 return json.loads(response.channel_infos)
-            elif not conf.LOAD_PEERS_FROM_IISS:
-                return utils.load_json_data(conf.CHANNEL_MANAGE_DATA_PATH)
-            else:
+            elif conf.LOAD_PEERS_FROM_IISS:
                 # this is temporary code for legacy support, and will be removed at next release.
                 return {channel: {'score_package': DEFAULT_SCORE_PACKAGE}
                         for channel in conf.CHANNEL_OPTION}
+            else:
+                return utils.load_json_data(conf.CHANNEL_MANAGE_DATA_PATH)
 
         return {channel: {'score_package': DEFAULT_SCORE_PACKAGE}
                 for channel in conf.CHANNEL_OPTION}

--- a/loopchain/utils/loggers/configuration.py
+++ b/loopchain/utils/loggers/configuration.py
@@ -33,7 +33,6 @@ class LogConfiguration:
         self.service_type = ""
         self.peer_id = ""
         self.channel_name = ""
-        self.score_package = ""
         self.log_level = verboselogs.SPAM
         self.log_color = True
         self.log_output_type = conf.LogOutputType.console
@@ -63,8 +62,7 @@ class LogConfiguration:
         if logger is logging.root:
             self._log_format = self.log_format.format(
                 PEER_ID=self.peer_id[:8] if self.peer_id != "RadioStation" else self.peer_id,
-                CHANNEL_NAME=self.channel_name,
-                SCORE_PACKAGE=self.score_package and f"({self.score_package})"
+                CHANNEL_NAME=self.channel_name
             )
 
             self._update_log_output_type()
@@ -120,11 +118,10 @@ class LogConfiguration:
                             level=self._log_level)
 
     def _update_log_file_path(self):
-        log_file_name = self.log_file_prefix + "{SERVICE_TYPE}{CHANNEL_NAME}{SCORE_PACKAGE}"
+        log_file_name = self.log_file_prefix + "{SERVICE_TYPE}{CHANNEL_NAME}"
         log_file_name = log_file_name.format(
             SERVICE_TYPE=self.service_type and f".{self.service_type}",
-            CHANNEL_NAME=self.channel_name and f".{self.channel_name}",
-            SCORE_PACKAGE=self.score_package and f".{self.score_package}"
+            CHANNEL_NAME=self.channel_name and f".{self.channel_name}"
         ).replace(r"/", r"_")
         log_file_name += f".{self.log_file_extension}"
 


### PR DESCRIPTION
- remove "node_getChannelInfos" call in citizen node, and replace it with "rep_getList".
- directly load channel_manage_data from file in channel_service if needed, not in peer_service.
- remove usage of channel_infos (except for legacy support).