### PR TITLE
[LC-472] set package version for ICON and add into status_data

### DIFF
--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -603,6 +603,7 @@ class ChannelInnerTask:
         status_data["peer_count"] = len(self._channel_service.peer_manager.peer_list)
         status_data["leader"] = self._channel_service.peer_manager.leader_id or ""
         status_data["epoch_leader"] = self._block_manager.epoch.leader_id if self._block_manager.epoch else ""
+        status_data["versions"] = conf.ICON_VERSIONS
 
         return status_data
 

--- a/loopchain/configure.py
+++ b/loopchain/configure.py
@@ -18,6 +18,7 @@ import importlib
 import json
 import logging
 import re
+import pkg_resources
 
 import loopchain
 from loopchain.components.singleton import SingletonMetaClass
@@ -43,6 +44,7 @@ class Configure(metaclass=SingletonMetaClass):
         # configure_info_list = {configure_attr: configure_type}
         self.__configure_info_list = {}
         self.__load_configure(loopchain.configure_default, use_env=True)
+        self._set_package_version()
 
     @property
     def configure_info_list(self):
@@ -120,8 +122,8 @@ class Configure(metaclass=SingletonMetaClass):
         # turn configure value to int or float after some condition check.
         # cast type string to original type if it exists in the globals().
         target_value = value
-        if isinstance(value, str) and len(value) > 0 and \
-                target_value_type is not str:
+        if (isinstance(value, str) and len(value) > 0
+                and target_value_type is not str):
             if re.match("^\d+?\.\d+?$", value) is not None:
                 # print("float configure value")
                 try:
@@ -139,6 +141,13 @@ class Configure(metaclass=SingletonMetaClass):
                 dict_data[key] = value.value
             elif isinstance(value, dict):
                 self.__change_enum_to_int(value)
+
+    def _set_package_version(self):
+        installed_pkg = [package.project_name for package in pkg_resources.working_set]
+        filtered_pkg = [pkg for pkg in installed_pkg if pkg in globals()['ICON_VERSIONS'].keys()]
+        for package in filtered_pkg:
+            version = pkg_resources.get_distribution(package).version
+            globals()['ICON_VERSIONS'][package] = version
 
 
 def get_configuration(configure_name):

--- a/loopchain/configure_default.py
+++ b/loopchain/configure_default.py
@@ -365,8 +365,6 @@ PRIVATE_PASSWORD = None
 
 # KMS
 KMS_AGENT_PASSWORD = ""
-KMS_SIGNATURE_KEY_ID = ""
-KMS_SIGNATURE_KEY_ID_LIST = {}
 KMS_TLS_KEY_ID = ""
 KMS_SECRET_KEY_LABEL = "KEY_ENCRYPTION"
 
@@ -415,6 +413,14 @@ CONF_PATH_ICONRPCSERVER_DEV = os.path.join(LOOPCHAIN_ROOT_PATH, 'conf/develop/ic
 CONF_PATH_ICONRPCSERVER_TESTNET = os.path.join(LOOPCHAIN_ROOT_PATH, 'conf/testnet/iconrpcserver_conf.json')
 CONF_PATH_ICONRPCSERVER_MAINNET = os.path.join(LOOPCHAIN_ROOT_PATH, 'conf/mainnet/iconrpcserver_conf.json')
 CREP_ROOT_HASH = ''
+ICON_VERSIONS = {
+    'loopchain': '0.0.0',
+    'iconservice': '0.0.0',
+    'iconrpcserver': '0.0.0',
+    'iconcommons': '0.0.0',
+    'tbears': '0.0.0',
+    'earlgrey': '0.0.0'
+}
 
 ####################
 # QOS ####


### PR DESCRIPTION
Print versions related to ICON project in `/staus/peer` api.

The list of packages can also be configured, default version as "0.0.0" (displayed version if not installed).

```javascript
// response example
{
    "made_block_count": 0,
    "status": "Service is online: 1",
    "state": "BlockGenerate",
    "service_available": true,
    "peer_type": "1",
    "audience_count": "0",
    "consensus": "siever",
    "peer_id": "hx86aba2210918a9b116973f3c4b27c41a54d5dafe",
    "block_height": 0,
    "round": 0,
    "epoch_height": 1,
    "unconfirmed_block_height": -1,
    "total_tx": 0,
    "unconfirmed_tx": 0,
    "peer_target": "10.211.0.202:7100",
    "leader_complaint": 1,
    "peer_count": 7,
    "leader": "hx86aba2210918a9b116973f3c4b27c41a54d5dafe",
    "epoch_leader": "hx86aba2210918a9b116973f3c4b27c41a54d5dafe",
    "versions": {
        "loopchain": "2.2.3",
        "iconservice": "1.3.4",
        "iconrpcserver": "1.3.3",
        "iconcommons": "1.1.0",
        "tbears": "1.3.0",
        "earlgrey": "0.0.4"
    },
    "mq": {
        "peer": {
            "message_count": 0
        },
        "channel": {
            "message_count": 0
        },
        "score": {
            "message_count": 0
        }
    }
}
```