### PR TITLE
[LC-492] rollback getChannelInfos request

### DIFF
--- a/loopchain/baseservice/rest_stub_manager.py
+++ b/loopchain/baseservice/rest_stub_manager.py
@@ -42,6 +42,7 @@ class RestStubManager:
                 self._http_clients[url] = HTTPClient(url)
 
         self._method_versions = {
+            "GetChannelInfos": conf.ApiVersion.node,
             "GetBlockByHeight": conf.ApiVersion.node,
             "Status": conf.ApiVersion.v1,
             "GetLastBlock": conf.ApiVersion.v3,
@@ -49,6 +50,7 @@ class RestStubManager:
         }
 
         self._method_names = {
+            "GetChannelInfos": "node_getChannelInfos",
             "GetBlockByHeight": "node_getBlockByHeight",
             "Status": "/status/peer/",
             "GetLastBlock": "icx_getLastBlock",

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -446,9 +446,14 @@ class ChannelService:
             self.__peer_manager.add_peer(peer_info)
 
     async def _load_peers_from_rest_call(self):
-        response = self.__radio_station_stub.call("GetReps")
-        reps = response.get('rep')
-        self._add_reps(reps)
+        # FIXME temporarily disable GetReps API for legacy support
+        # response = self.__radio_station_stub.call("GetReps")
+        # reps = response.get('rep')
+        # self._add_reps(reps)
+        response = self.__radio_station_stub.call("GetChannelInfos")
+        reps: list = response['channel_infos'][ChannelProperty().name].get('peers')
+        for peer_info in reps:
+            self.__peer_manager.add_peer(peer_info)
 
     def _add_reps(self, reps: list):
         for order, rep_info in enumerate(reps, 1):

--- a/loopchain/peer/peer_service.py
+++ b/loopchain/peer/peer_service.py
@@ -168,9 +168,9 @@ class PeerService:
                         for channel in conf.CHANNEL_OPTION}
             else:
                 return utils.load_json_data(conf.CHANNEL_MANAGE_DATA_PATH)
-
-        return {channel: {'score_package': DEFAULT_SCORE_PACKAGE}
-                for channel in conf.CHANNEL_OPTION}
+        else:
+            response = self.stub_to_radiostation.call("GetChannelInfos")
+            return {channel: value for channel, value in response["channel_infos"].items()}
 
     def _init_port(self, port):
         # service 초기화 작업


### PR DESCRIPTION
- temporarily disable `rep_getList` for legacy support
- set citizen's channel_infos based on parent's channel_info