### PR TITLE
[LC-516] Prevent the occurrence of `TransactionDuplicatedError` and process the case that voters of quorum or above vote against a block.

### DIFF
--- a/loopchain/baseservice/aging_cache.py
+++ b/loopchain/baseservice/aging_cache.py
@@ -13,8 +13,9 @@
 # limitations under the License.
 """Custom Dictionary type that has limit size by timestamp"""
 
-import time
 import threading
+import time
+
 from collections import OrderedDict, MutableMapping
 
 

--- a/loopchain/baseservice/timer_service.py
+++ b/loopchain/baseservice/timer_service.py
@@ -239,7 +239,7 @@ class TimerService(CommonThread):
         try:
             timer_in_list = self.__timer_list[key]
         except KeyError:
-            util.logger.spam(f"There is no timer of {key} in {self.__timer_list}")
+            util.logger.spam(f"There is no timer of {key} in {self.__timer_list.keys()}")
         else:
             if timer is not timer_in_list:
                 util.logger.spam(f"Different timer object.")

--- a/loopchain/baseservice/timer_service.py
+++ b/loopchain/baseservice/timer_service.py
@@ -239,9 +239,10 @@ class TimerService(CommonThread):
         try:
             timer_in_list = self.__timer_list[key]
         except KeyError:
-            pass
+            util.logger.spam(f"There is no timer of {key} in {self.__timer_list}")
         else:
             if timer is not timer_in_list:
+                util.logger.spam(f"Different timer object.")
                 return
 
             if timer.is_repeat:

--- a/loopchain/baseservice/timer_service.py
+++ b/loopchain/baseservice/timer_service.py
@@ -242,7 +242,6 @@ class TimerService(CommonThread):
             util.logger.spam(f"There is no timer of {key} in {self.__timer_list.keys()}")
         else:
             if timer is not timer_in_list:
-                util.logger.spam(f"Different timer object.")
                 return
 
             if timer.is_repeat:

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -131,8 +131,6 @@ class BlockChain:
         else:
             self.__made_block_counter[block.header.peer_id] += 1
 
-        utils.logger.spam(f"({block.header.height})made_block_count:\n{self.__made_block_counter}")
-
     def reset_leader_made_block_count(self):
         self.__made_block_counter.clear()
 

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -830,10 +830,6 @@ class BlockChain:
         :param current_block: Next unconfirmed block what has votes for prev unconfirmed block.
         :return: confirm_Block
         """
-        # utils.logger.debug(f"-------------------confirm_prev_block---current_block is "
-        #                    f"tx count({len(current_block.body.transactions)}), "
-        #                    f"height({current_block.header.height})")
-
         candidate_blocks = self.__block_manager.candidate_blocks
         with self.__confirmed_block_lock:
             logging.debug(f"BlockChain:confirm_block channel({self.__channel_name})")
@@ -865,8 +861,6 @@ class BlockChain:
                 logging.warning("It's not possible to add block while check block hash is fail-")
                 raise BlockchainError('확인하는 블럭 해쉬 값이 다릅니다.')
 
-            # utils.logger.debug(f"-------------------confirm_prev_block---before add block,"
-            #                    f"height({unconfirmed_block.header.height})")
             confirm_info = current_block.body.prev_votes if current_block.header.version == "0.3" else None
             self.add_block(unconfirmed_block, confirm_info)
             self.last_unconfirmed_block = current_block
@@ -910,7 +904,6 @@ class BlockChain:
             with open(genesis_data_path, encoding="utf-8") as json_file:
                 tx_info = json.load(json_file)["transaction_data"]
                 nid = tx_info["nid"]
-                # utils.logger.spam(f"generate_genesis_block::tx_info >>>> {tx_info}")
 
         except FileNotFoundError as e:
             exit(f"cannot open json file in ({genesis_data_path}): {e}")

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -820,6 +820,10 @@ class BlockChain:
 
         return results
 
+    def __is_1st_block_of_new_term(self, unconfirmed_block_header, current_block_header):
+        reps = self.find_preps_addresses_by_roothash(current_block_header.reps_hash)
+        return unconfirmed_block_header.next_leader not in reps and current_block_header.peer_id == reps[0]
+
     def confirm_prev_block(self, current_block: Block):
         """confirm prev unconfirmed block by votes in current block
 
@@ -843,8 +847,9 @@ class BlockChain:
             except KeyError:
                 if self.last_block.header.hash == current_block.header.prev_hash:
                     logging.warning(f"Already added block hash({current_block.header.prev_hash.hex()})")
-                    if current_block.header.complained and self.__block_manager.epoch.complained_result:
-                        utils.logger.debug("reset last_unconfirmed_block by complain block")
+                    if (current_block.header.complained and self.__block_manager.epoch.complained_result)\
+                            or self.__is_1st_block_of_new_term(self.last_block.header, current_block.header):
+                        utils.logger.debug("reset last_unconfirmed_block by complain block or first block of new term.")
                         self.last_unconfirmed_block = current_block
                     return None
                 else:

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -423,6 +423,7 @@ class BlockChain:
             receipts, next_prep = self.__invoke_results.get(block.header.hash, (None, None))
             if receipts is None and need_to_score_invoke:
                 self.get_invoke_func(block.header.height)(block, self.__last_block)
+                receipts, next_prep = self.__invoke_results.get(block.header.hash, (None, None))
 
             if not need_to_write_tx_info:
                 receipts = None

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -335,6 +335,7 @@ class BlockChain:
         try:
             return self._blockchain_store.get(BlockChain.CONFIRM_INFO_KEY + hash_encoded)
         except KeyError:
+            utils.logger.spam(f"There is no block by hash: {block_hash}")
             block = self.find_block_by_hash(block_hash)
             return self.find_prev_confirm_info_by_height(block.header.height + 1) if block else bytes()
 
@@ -698,9 +699,6 @@ class BlockChain:
         try:
             tx_info_json = self.find_tx_info(tx_hash_key)
         except KeyError as e:
-            # This case is not an error.
-            # Client send wrong tx_hash..
-            # logging.warning(f"[blockchain::find_tx_by_key] Transaction is pending. tx_hash ({tx_hash_key})")
             return None
         if tx_info_json is None:
             logging.warning(f"tx not found. tx_hash ({tx_hash_key})")
@@ -745,9 +743,6 @@ class BlockChain:
         except UnicodeDecodeError as e:
             logging.warning("blockchain::find_tx_info: UnicodeDecodeError: " + str(e))
             return None
-        # except KeyError as e:
-        #     logging.debug("blockchain::find_tx_info: not found tx: " + str(e))
-        #     return None
 
         return tx_info_json
 

--- a/loopchain/blockchain/blocks/block_verifier.py
+++ b/loopchain/blockchain/blocks/block_verifier.py
@@ -68,6 +68,10 @@ class BlockVerifier(ABC):
         return self._verify_common(block, prev_block, generator, **kwargs)
 
     @abstractmethod
+    def verify_invoke(self, builder: 'BlockBuilder', block: 'Block', prev_block: 'Block'):
+        raise NotImplementedError
+
+    @abstractmethod
     def _verify_common(self, block: 'Block', prev_block: 'Block', generator: 'ExternalAddress'=None, **kwargs):
         raise NotImplementedError
 

--- a/loopchain/blockchain/blocks/v0_1a/block_verifier.py
+++ b/loopchain/blockchain/blocks/v0_1a/block_verifier.py
@@ -28,23 +28,7 @@ class BlockVerifier(BaseBlockVerifier):
 
         invoke_result = None
         if self.invoke_func:
-            try:
-                new_block, invoke_result = self.invoke_func(block, prev_block)
-            except GenericJsonRpcServerError as e:
-                if hasattr(e, 'message') and 'Failed to invoke a block' in e.message:
-                    e = ScoreInvokeError(f"{e.message} with block({header.hash.hex()})")
-                self._handle_exception(e)
-            except Exception as e:
-                self._handle_exception(e)
-            else:
-                if not header.commit_state and len(body.transactions) == 0:
-                    # vote block
-                    pass
-                elif header.commit_state != new_block.header.commit_state:
-                    exception = ScoreInvokeResultError(f"Block({header.height}, {header.hash.hex()}, "
-                                                       f"CommitState({header.commit_state}), "
-                                                       f"Expected({new_block.header.commit_state}).")
-                    self._handle_exception(exception)
+            self.verify_invoke(builder, block, prev_block)
 
         builder.build_merkle_tree_root_hash()
         if header.merkle_tree_root_hash != builder.merkle_tree_root_hash:
@@ -64,6 +48,26 @@ class BlockVerifier(BaseBlockVerifier):
             self.verify_generator(block, generator)
 
         return invoke_result
+
+    def verify_invoke(self, builder: 'BlockBuilder', block: 'Block', prev_block: 'Block'):
+        header: BlockHeader = block.header
+        try:
+            new_block, invoke_result = self.invoke_func(block, prev_block)
+        except GenericJsonRpcServerError as e:
+            if hasattr(e, 'message') and 'Failed to invoke a block' in e.message:
+                e = ScoreInvokeError(f"{e.message} with block({header.hash.hex()})")
+            self._handle_exception(e)
+        except Exception as e:
+            self._handle_exception(e)
+        else:
+            if not header.commit_state and len(block.body.transactions) == 0:
+                # vote block
+                pass
+            elif header.commit_state != new_block.header.commit_state:
+                exception = ScoreInvokeResultError(f"Block({header.height}, {header.hash.hex()}, "
+                                                   f"CommitState({header.commit_state}), "
+                                                   f"Expected({new_block.header.commit_state}).")
+                self._handle_exception(exception)
 
     def verify_prev_block(self, block: 'Block', prev_block: 'Block'):
         super().verify_prev_block(block, prev_block)

--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -177,8 +177,15 @@ class Epoch:
         if self.__blockchain.last_unconfirmed_block and \
                 self.__blockchain.last_unconfirmed_block.header.peer_id != ChannelProperty().peer_address:
             tx_queue = self.__block_manager.get_tx_queue()
-            for tx_hash_in_unconfirmed_block in self.__blockchain.last_unconfirmed_block.body.transactions:
-                tx_queue.pop(tx_hash_in_unconfirmed_block.hex(), None)
+            try:
+                for tx_hash_in_unconfirmed_block in self.__blockchain.last_unconfirmed_block.body.transactions:
+                    tx_queue.set_item_status(
+                        tx_hash_in_unconfirmed_block.hex(),
+                        TransactionStatusInQueue.added_to_block)
+                    # utils.logger.spam(f"remove duplicated tx. {tx_hash_in_unconfirmed_block.hex()}")
+            except KeyError:
+                # utils.logger.spam("There is no duplicated tx.")
+                return
 
     def makeup_block(self, complain_votes: LeaderVotes, prev_votes):
         last_block = self.__blockchain.last_unconfirmed_block or self.__blockchain.last_block

--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -141,9 +141,10 @@ class Epoch:
         tx_versioner = self.__blockchain.tx_versioner
         while tx_queue:
             if block_tx_size >= conf.MAX_TX_SIZE_IN_BLOCK:
-                logging.debug(f"consensus_base total size({block_builder.size()}) "
-                              f"count({len(block_builder.transactions)}) "
-                              f"_txQueue size ({len(tx_queue)})")
+                logging.warning(
+                    f"consensus_base total size({block_builder.size()}) "
+                    f"count({len(block_builder.transactions)}) "
+                    f"_txQueue size ({len(tx_queue)})")
                 break
 
             tx: 'Transaction' = tx_queue.get_item_in_status(

--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -177,15 +177,15 @@ class Epoch:
         if self.__blockchain.last_unconfirmed_block and \
                 self.__blockchain.last_unconfirmed_block.header.peer_id != ChannelProperty().peer_address:
             tx_queue = self.__block_manager.get_tx_queue()
-            try:
-                for tx_hash_in_unconfirmed_block in self.__blockchain.last_unconfirmed_block.body.transactions:
+
+            for tx_hash_in_unconfirmed_block in self.__blockchain.last_unconfirmed_block.body.transactions:
+                try:
                     tx_queue.set_item_status(
                         tx_hash_in_unconfirmed_block.hex(),
                         TransactionStatusInQueue.added_to_block)
-                    # utils.logger.spam(f"remove duplicated tx. {tx_hash_in_unconfirmed_block.hex()}")
-            except KeyError:
-                # utils.logger.spam("There is no duplicated tx.")
-                return
+                except KeyError:
+                    continue
+            utils.logger.spam(f"There is no duplicated tx anymore.")
 
     def makeup_block(self, complain_votes: LeaderVotes, prev_votes):
         last_block = self.__blockchain.last_unconfirmed_block or self.__blockchain.last_block

--- a/loopchain/blockchain/exception.py
+++ b/loopchain/blockchain/exception.py
@@ -14,15 +14,15 @@
 """A module of exceptions for errors on block chain"""
 
 from typing import TYPE_CHECKING
-from loopchain.protos import message_code
 
+from loopchain.protos import message_code
 
 if TYPE_CHECKING:
     from loopchain.blockchain.transactions import Transaction
     from loopchain.blockchain.types import Hash32
 
 
-class BlockInValidError(Exception):
+class InvalidBlock(Exception):
     """블럭 검증오류
     검증되지 않은 블럭이 블럭체인에 추가되거나, 검증시 hash값이 다르다면 발생한다
     """

--- a/loopchain/blockchain/exception.py
+++ b/loopchain/blockchain/exception.py
@@ -23,8 +23,7 @@ if TYPE_CHECKING:
 
 
 class InvalidBlock(Exception):
-    """블럭 검증오류
-    검증되지 않은 블럭이 블럭체인에 추가되거나, 검증시 hash값이 다르다면 발생한다
+    """Raise when an invalid block tries to be added.
     """
     pass
 

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -715,9 +715,8 @@ class ChannelInnerTask:
 
         try:
             self._block_manager.verify_confirm_info(unconfirmed_block)
-        except ConfirmInfoInvalid:
-            # TODO
-            pass
+        except ConfirmInfoInvalid as e:
+            util.logger.debug(f"ConfirmInfoInvalid {e}")
         except ConfirmInfoInvalidNeedBlockSync as e:
             util.logger.debug(f"ConfirmInfoInvalidNeedBlockSync {e}")
             if self._channel_service.state_machine.state == "BlockGenerate" and (

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -781,10 +781,6 @@ class ChannelInnerTask:
             raise
         else:
             vote = BlockVote.deserialize(vote_serialized)
-
-            util.logger.spam(f"channel_inner_service:vote_unconfirmed_block "
-                             f"({ChannelProperty().name}) block_hash({vote.block_hash})")
-
             util.logger.debug(f"Peer vote to : {vote.block_height} {vote.block_hash} from {vote.rep.hex_hx()}")
             self._block_manager.candidate_blocks.add_vote(vote)
 

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -716,7 +716,7 @@ class ChannelInnerTask:
         try:
             self._block_manager.verify_confirm_info(unconfirmed_block)
         except ConfirmInfoInvalid as e:
-            util.logger.debug(f"ConfirmInfoInvalid {e}")
+            util.logger.warning(f"ConfirmInfoInvalid {e}")
         except ConfirmInfoInvalidNeedBlockSync as e:
             util.logger.debug(f"ConfirmInfoInvalidNeedBlockSync {e}")
             if self._channel_service.state_machine.state == "BlockGenerate" and (
@@ -725,7 +725,7 @@ class ChannelInnerTask:
             else:
                 self._channel_service.state_machine.block_sync()
         except ConfirmInfoInvalidAddedBlock as e:
-            util.logger.debug(f"ConfirmInfoInvalidAddedBlock {e}")
+            util.logger.warning(f"ConfirmInfoInvalidAddedBlock {e}")
         else:
             if self._channel_service.state_machine.state in ("Vote", "Watch", "LeaderComplain"):
                 self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block)

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -290,7 +290,6 @@ class BlockManager:
                     raise BlockchainError(f"last block is not previous block. block={unconfirmed_block}")
 
                 self.blockchain.last_unconfirmed_block = unconfirmed_block
-                self.__channel_service.stop_leader_complain_timer()
         except BlockchainError as e:
             logging.warning(f"BlockchainError while confirm_block({e}), retry block_height_sync")
             self.__channel_service.state_machine.block_sync()

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -629,11 +629,10 @@ class BlockManager:
         return True
 
     def start_epoch(self):
-        curr_block_header = self.__current_last_block().header
-        current_height = curr_block_header.height
-        next_leader = curr_block_header.next_leader
-        leader_peer = \
-            self.__channel_service.peer_manager.get_peer(next_leader.hex_hx()) if next_leader else None
+        current_block_header = self.__current_last_block().header
+        current_height = current_block_header.height
+        next_leader = current_block_header.next_leader
+        leader_peer = self.__channel_service.peer_manager.get_peer(next_leader.hex_hx()) if next_leader else None
 
         if leader_peer:
             self.epoch = Epoch.new_epoch(leader_peer.peer_id)
@@ -784,7 +783,7 @@ class BlockManager:
 
         block_verifier = BlockVerifier.new(unconfirmed_block.header.version, self.blockchain.tx_versioner)
         last_unconfirmed_block = self.blockchain.last_unconfirmed_block
-        prev_block = last_unconfirmed_block if last_unconfirmed_block else self.blockchain.last_block
+        prev_block = last_unconfirmed_block or self.blockchain.last_block
         reps_getter = self.blockchain.find_preps_addresses_by_roothash
         try:
             if unconfirmed_block.header.version != "0.1a" and unconfirmed_block.header.height > 1:

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -17,9 +17,10 @@ import json
 import logging
 import threading
 import traceback
-from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, Future
 from typing import TYPE_CHECKING, Dict, DefaultDict
+
+from collections import defaultdict
 
 import loopchain.utils as util
 from loopchain import configure as conf
@@ -233,9 +234,6 @@ class BlockManager:
         confirmed_block = self.blockchain.confirm_prev_block(current_block)
         if confirmed_block is None:
             return
-
-        # stop leader complain timer
-        self.__channel_service.stop_leader_complain_timer()
 
         # start new epoch
         if not (current_block.header.complained and self.epoch.complained_result):
@@ -774,11 +772,6 @@ class BlockManager:
         return vote
 
     def verify_confirm_info(self, unconfirmed_block: Block):
-        # TODO set below variable with right result.
-        check_unconfirmed_block_has_valid_confirm_info_for_prev_block = True
-        if not check_unconfirmed_block_has_valid_confirm_info_for_prev_block:
-            raise ConfirmInfoInvalid("Unconfirmed block has no valid confirm info for previous block")
-
         my_height = self.blockchain.block_height
         if my_height < (unconfirmed_block.header.height - 2):
             raise ConfirmInfoInvalidNeedBlockSync(f"trigger block sync in _vote my_height({my_height}), "
@@ -788,6 +781,22 @@ class BlockManager:
         if my_height >= unconfirmed_block.header.height:
             raise ConfirmInfoInvalidAddedBlock(f"block is already added my_height({my_height}), "
                                                f"unconfirmed_block.header.height({unconfirmed_block.header.height})")
+
+        block_verifier = BlockVerifier.new(unconfirmed_block.header.version, self.blockchain.tx_versioner)
+        last_unconfirmed_block = self.blockchain.last_unconfirmed_block
+        prev_block = last_unconfirmed_block if last_unconfirmed_block else self.blockchain.last_block
+        reps_getter = self.blockchain.find_preps_addresses_by_roothash
+        try:
+            if unconfirmed_block.header.height > 1:
+                if prev_block.header.version != "0.1a":
+                    prev_reps = reps_getter(prev_block.header.reps_hash)
+                else:
+                    prev_reps = reps_getter(unconfirmed_block.header.reps_hash)
+                block_verifier.verify_prev_votes(unconfirmed_block, prev_reps)
+        except Exception as e:
+            logging.warning(e)
+            traceback.print_exc()
+            raise ConfirmInfoInvalid("Unconfirmed block has no valid confirm info for previous block")
 
     async def _vote(self, unconfirmed_block: Block):
         exc = None

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -787,7 +787,7 @@ class BlockManager:
         prev_block = last_unconfirmed_block if last_unconfirmed_block else self.blockchain.last_block
         reps_getter = self.blockchain.find_preps_addresses_by_roothash
         try:
-            if unconfirmed_block.header.height > 1:
+            if unconfirmed_block.header.version != "0.1a" and unconfirmed_block.header.height > 1:
                 if prev_block.header.version != "0.1a":
                     prev_reps = reps_getter(prev_block.header.reps_hash)
                 else:

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -172,7 +172,7 @@ class ConsensusSiever(ConsensusBase):
                 need_next_call = True
             except ThereIsNoCandidateBlock:
                 util.logger.debug(
-                    f"Not Candidate Block height({last_unconfirmed_block.header.height})")
+                    f"There is no candidate block by height({last_unconfirmed_block.header.height}).")
                 self._block_manager.epoch = Epoch.new_epoch(ChannelProperty().peer_id)
                 block_builder = self._makeup_new_block(
                     block_builder.version, complain_votes, self._blockchain.last_block.header.hash)
@@ -257,7 +257,7 @@ class ConsensusSiever(ConsensusBase):
             prev_votes = None
 
         if prev_votes:
-            if not (prev_votes and prev_votes.is_completed()):
+            if not prev_votes.is_completed():
                 self.__broadcast_block(self._blockchain.last_unconfirmed_block)
                 if await self._wait_for_voting(self._blockchain.last_unconfirmed_block) is None:
                     return None

--- a/testcase/unittest/test_block.py
+++ b/testcase/unittest/test_block.py
@@ -16,19 +16,19 @@
 # limitations under the License.
 """Test Block functions"""
 
-import logging
 import json
+import logging
 import os
 import random
 import sys
 import unittest
 
-from loopchain import utils
 import testcase.unittest.test_util as test_util
-
 from cli_tools.icx_test.icx_wallet import IcxWallet
 from loopchain import configure as conf
+from loopchain import utils
 from loopchain.baseservice import ObjectManager
+from loopchain.blockchain import InvalidBlock
 from loopchain.crypto.signature import Signer
 from testcase.unittest.mock_peer import set_mock
 
@@ -124,7 +124,7 @@ class TestBlock(unittest.TestCase):
         invalid_signature_block = self.__generate_invalid_block()
 
         # WHEN THEN
-        with self.assertRaises(BlockInValidError):
+        with self.assertRaises(InvalidBlock):
             Block.validate(invalid_signature_block)
 
     @unittest.skip("BVS")


### PR DESCRIPTION
Currently, a leader can bond invalid block and occur a problem even though voters of quorum or above vote against a block. That's why I add logic to process by a leader to avoid bonding any invalid block in Siever. And I add logic to prevent the occurrence of `TransactionDuplicatedError` because `tx_info` doesn't be stored if the block, it includes the transaction of `tx_info`, has been never invoked.