### PR TITLE
[LC-543] Less responsibility of ChannelProperty

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -1114,7 +1114,6 @@ class BlockChain:
 
         self.__add_genesis_block(tx_info, reps)
         self.put_nid(nid)
-        ChannelProperty().nid = nid
 
         utils.logger.spam(f"add_genesis_block({self.__channel_name}/nid({nid}))")
 

--- a/loopchain/channel/channel_property.py
+++ b/loopchain/channel/channel_property.py
@@ -26,7 +26,6 @@ class ChannelProperty(metaclass=SingletonMetaClass):
         self.peer_target = None
         self.rest_target = None
         self.rs_target = None
-        self.peer_port = None
         self.peer_id = None
         self.peer_address: Optional[ExternalAddress] = None
         self.peer_auth = None

--- a/loopchain/channel/channel_property.py
+++ b/loopchain/channel/channel_property.py
@@ -24,7 +24,6 @@ class ChannelProperty(metaclass=SingletonMetaClass):
     def __init__(self):
         self.name = None
         self.peer_target = None
-        self.rs_target = None
         self.peer_id = None
         self.peer_address: Optional[ExternalAddress] = None
         self.peer_auth = None

--- a/loopchain/channel/channel_property.py
+++ b/loopchain/channel/channel_property.py
@@ -26,7 +26,6 @@ class ChannelProperty(metaclass=SingletonMetaClass):
         self.peer_target = None
         self.rest_target = None
         self.rs_target = None
-        self.amqp_target = None
         self.peer_port = None
         self.peer_id = None
         self.peer_address: Optional[ExternalAddress] = None

--- a/loopchain/channel/channel_property.py
+++ b/loopchain/channel/channel_property.py
@@ -24,7 +24,6 @@ class ChannelProperty(metaclass=SingletonMetaClass):
     def __init__(self):
         self.name = None
         self.peer_target = None
-        self.rest_target = None
         self.rs_target = None
         self.peer_id = None
         self.peer_address: Optional[ExternalAddress] = None

--- a/loopchain/channel/channel_property.py
+++ b/loopchain/channel/channel_property.py
@@ -29,5 +29,4 @@ class ChannelProperty(metaclass=SingletonMetaClass):
         self.peer_address: Optional[ExternalAddress] = None
         self.peer_auth = None
         self.node_type = None
-        self.nid = None
         self.crep_root_hash = None

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -51,6 +51,7 @@ class ChannelService:
         self.__consensus = None
         self.__timer_service = TimerService()
         self.__node_subscriber: NodeSubscriber = None
+        self.__rest_target = None
 
         loggers.get_preset().channel_name = channel_name
         loggers.get_preset().update_logger()
@@ -181,7 +182,7 @@ class ChannelService:
         loggers.get_preset().update_logger()
 
         ChannelProperty().peer_target = kwargs.get('peer_target')
-        ChannelProperty().rest_target = kwargs.get('rest_target')
+        self.__rest_target = kwargs.get('rest_target')
         ChannelProperty().peer_id = kwargs.get('peer_id')
         ChannelProperty().peer_address = ExternalAddress.fromhex_address(ChannelProperty().peer_id)
         ChannelProperty().node_type = conf.NodeType.CitizenNode
@@ -298,7 +299,7 @@ class ChannelService:
 
         radiostations = utils.convert_local_ip_to_private_ip(radiostations)
         try:
-            radiostations.remove(ChannelProperty().rest_target)
+            radiostations.remove(self.__rest_target)
         except ValueError:
             pass
 
@@ -396,8 +397,9 @@ class ChannelService:
                 else:
                     logging.warning(f"Waiting for next subscribe request...")
 
-        utils.logger.spam(f"try subscribe_call_by_citizen target({ChannelProperty().rest_target})")
+        utils.logger.spam(f"try subscribe_call_by_citizen target({self.__rest_target})")
         subscribe_event = asyncio.Event()
+
         # try websocket connection, and handle exception in callback
         task = asyncio.ensure_future(
             self.__node_subscriber.start(

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -180,7 +180,6 @@ class ChannelService:
         loggers.get_preset().peer_id = kwargs.get('peer_id')
         loggers.get_preset().update_logger()
 
-        ChannelProperty().peer_port = kwargs.get('peer_port')
         ChannelProperty().peer_target = kwargs.get('peer_target')
         ChannelProperty().rest_target = kwargs.get('rest_target')
         ChannelProperty().peer_id = kwargs.get('peer_id')

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -62,7 +62,6 @@ class ChannelService:
         logging.info(f"ChannelService : {channel_name}, Queue : {channel_queue_name}")
 
         ChannelProperty().name = channel_name
-        ChannelProperty().amqp_target = amqp_target
         ChannelProperty().crep_root_hash = Hash32.fromhex(conf.CHANNEL_OPTION[channel_name].get('crep_root_hash'))
 
         StubCollection().amqp_key = amqp_key

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -353,8 +353,6 @@ class BlockManager:
         if nid is None:
             genesis_block = self.blockchain.find_block_by_height(0)
             self.__rebuild_nid(genesis_block)
-        else:
-            ChannelProperty().nid = nid
 
     def __rebuild_nid(self, block: Block):
         nid = NID.unknown.value
@@ -372,7 +370,6 @@ class BlockManager:
             nid = hex(nid)
 
         self.blockchain.put_nid(nid)
-        ChannelProperty().nid = nid
 
     def block_height_sync(self):
         def _print_exception(fut):


### PR DESCRIPTION
Reduce responsibility of `ChannelProperty`

# Changes
- remove attrs from `ChannelProperty: 
  - `amqp_key`, `peer_port`, `rest_target`, `nid` (No reason for the class to have those attrs, due to recent changes)