### PR TITLE
[LC-547] fix log level when websocket connection closed

### DIFF
--- a/conf/testnet/loopchain_conf.json
+++ b/conf/testnet/loopchain_conf.json
@@ -5,7 +5,7 @@
         "0.1a": 0
       },
       "hash_versions": {
-        "genesis": 0,
+        "genesis": 1,
         "0x2": 1,
         "0x3": 1
       },

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -88,8 +88,7 @@ class NodeSubscriber:
             logging.error(f"{type(e)} during subscribe, caused by: {e}")
             raise e
         except Exception as e:
-            traceback.print_exc()
-            logging.error(f"{type(e)} during subscribe, caused by: {e}")
+            logging.info(f"{type(e)} during subscribe, caused by: {e}")
             raise ConnectionError
         finally:
             await self.close()

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -543,9 +543,11 @@ class BlockChain:
             self.write_preps(Hash32.fromhex(next_prep['rootHash'], ignore_prefix=True), next_prep['preps'], batch)
 
         if confirm_info:
+            if isinstance(confirm_info, list):
+                confirm_info = json.dumps(BlockVotes.serialize_votes(confirm_info))
             batch.put(
                 BlockChain.CONFIRM_INFO_KEY + block_hash_encoded,
-                json.dumps(BlockVotes.serialize_votes(confirm_info)).encode("utf-8")
+                confirm_info.encode("utf-8")
             )
 
         if block.header.prev_hash:


### PR DESCRIPTION
- fix log level when websocket connection is closed
- update testnet citizen conf
- support old confirm_info format when block sync