### PR TITLE
[LC-559] Fix a bug that two leaders exist.

### DIFF
--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -709,6 +709,10 @@ class ChannelInnerTask:
             f"height({unconfirmed_block.header.height})\n"
             f"hash({unconfirmed_block.header.hash.hex()})")
 
+        if self._channel_service.state_machine.state not in ("Vote", "Watch", "LeaderComplain"):
+            util.logger.debug(f"Can't add unconfirmed block in state({self._channel_service.state_machine.state}).")
+            return
+
         last_block = self._blockchain.last_block
         if last_block is None:
             util.logger.debug("BlockChain has not been initialized yet.")
@@ -728,10 +732,7 @@ class ChannelInnerTask:
         except ConfirmInfoInvalidAddedBlock as e:
             util.logger.warning(f"ConfirmInfoInvalidAddedBlock {e}")
         else:
-            if self._channel_service.state_machine.state in ("Vote", "Watch", "LeaderComplain"):
-                self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block)
-            else:
-                util.logger.debug(f"Can't add unconfirmed block in state({self._channel_service.state_machine.state}).")
+            self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block)
 
     @message_queue_task
     def block_sync(self, block_hash, block_height):

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -537,6 +537,7 @@ class ChannelService:
             self.state_machine.turn_to_peer()
 
         self.__block_manager.set_peer_type(peer_type)
+        self.turn_on_leader_complain_timer()
 
     def set_new_leader(self):
         new_leader_id = self.block_manager.get_next_leader()

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -234,11 +234,9 @@ class BlockManager:
         if confirmed_block is None:
             return
 
-        # start new epoch
         if not (current_block.header.complained and self.epoch.complained_result):
             self.epoch = Epoch.new_epoch()
 
-        # reset leader
         self.__channel_service.reset_leader(current_block.header.next_leader.hex_hx())
 
     def __validate_duplication_unconfirmed_block(self, unconfirmed_block: Block):
@@ -711,7 +709,6 @@ class BlockManager:
             elected_leader = self.epoch.complain_result()
             if elected_leader:
                 self.__channel_service.reset_leader(elected_leader, complained=True)
-                self.__channel_service.reset_leader_complain_timer()
             elif elected_leader is False:
                 util.logger.warning(f"Fail to elect the next leader on {self.epoch.round} round.")
                 # In this case, a new leader can't be elected by the consensus of leader complaint.
@@ -844,9 +841,6 @@ class BlockManager:
             vote = self.vote_unconfirmed_block(unconfirmed_block, is_validated)
             if self.__channel_service.state_machine.state == "BlockGenerate" and self.consensus_algorithm:
                 self.consensus_algorithm.vote(vote)
-
-            if is_validated:
-                self.__channel_service.turn_on_leader_complain_timer()
 
     async def vote_as_peer(self, unconfirmed_block: Block):
         """Vote to AnnounceUnconfirmedBlock

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -240,6 +240,9 @@ class BlockManager:
         self.__channel_service.reset_leader(current_block.header.next_leader.hex_hx())
 
     def __validate_duplication_unconfirmed_block(self, unconfirmed_block: Block):
+        if self.blockchain.last_block.header.height >= unconfirmed_block.header.height:
+            raise InvalidUnconfirmedBlock("The unconfirmed block has height already added.")
+
         last_unconfirmed_block: Block = self.blockchain.last_unconfirmed_block
         try:
             candidate_block = self.candidate_blocks.blocks[unconfirmed_block.header.hash].block
@@ -853,6 +856,7 @@ class BlockManager:
         try:
             self.add_unconfirmed_block(unconfirmed_block)
         except InvalidUnconfirmedBlock as e:
+            self.candidate_blocks.remove_block(unconfirmed_block.header.hash)
             util.logger.warning(e)
         except DuplicationUnconfirmedBlock as e:
             util.logger.debug(e)

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -136,13 +136,10 @@ class ConsensusSiever(ConsensusBase):
                 self._block_manager.epoch.remove_duplicate_tx_when_turn_to_leader()
 
             last_unconfirmed_block = self._blockchain.last_unconfirmed_block
-            last_block = last_unconfirmed_block or self._blockchain.last_block
+            latest_block = last_unconfirmed_block or self._blockchain.last_block
             last_block_header = self._blockchain.last_block.header
-
-            try:
-                last_block_vote_list = await self.get_votes(last_block.header.hash)
-            except TimeoutError:
-                util.logger.warning(f"Timeout block of hash : {last_block.header.hash}")
+            last_block_vote_list = await self.get_votes(latest_block.header.hash)
+            if last_block_vote_list is None:
                 return
 
             new_term = False
@@ -201,7 +198,7 @@ class ConsensusSiever(ConsensusBase):
             candidate_block = self.__build_candidate_block(
                 block_builder, ExternalAddress.fromhex_address(self._block_manager.epoch.leader_id))
             candidate_block, invoke_results = self._blockchain.score_invoke(
-                candidate_block, last_block, is_block_editable=True)
+                candidate_block, latest_block, is_block_editable=True)
 
             util.logger.spam(f"candidate block : {candidate_block.header}")
             self._block_manager.candidate_blocks.add_block(candidate_block)
@@ -258,7 +255,7 @@ class ConsensusSiever(ConsensusBase):
                 timeout = self.__check_timeout(block)
                 if not await asyncio.wait_for(self._vote_queue.get(), timeout=timeout):  # sentinel
                     raise NotEnoughVotes
-            except TimeoutError:
+            except (TimeoutError, asyncio.TimeoutError):
                 util.logger.warning("Timed Out Block not confirmed duration: " +
                                     str(util.diff_in_seconds(block.header.timestamp)))
                 raise NotEnoughVotes
@@ -280,10 +277,22 @@ class ConsensusSiever(ConsensusBase):
 
         if prev_votes:
             if not prev_votes.is_completed():
-                self.__check_timeout(self._blockchain.last_unconfirmed_block)
-                self.__broadcast_block(self._blockchain.last_unconfirmed_block)
-                if await self._wait_for_voting(self._blockchain.last_unconfirmed_block) is None:
+                try:
+                    last_unconfirmed_block = self._blockchain.last_unconfirmed_block
+                    self.__check_timeout(last_unconfirmed_block)
+                    self.__broadcast_block(last_unconfirmed_block)
+                    if await self._wait_for_voting(last_unconfirmed_block) is None:
+                        return None
+                except TimeoutError:
+                    util.logger.warning(f"Timeout block of hash : {block_hash}")
+                    self.__stop_broadcast_send_unconfirmed_block_timer()
                     return None
+                except NotEnoughVotes:
+                    if last_unconfirmed_block:
+                        util.logger.warning(f"The last unconfirmed block has not enough votes. {block_hash}")
+                        return None
+                    else:
+                        util.exit_and_msg(f"The block that has not enough votes added to the blockchain.")
 
             prev_votes_list = prev_votes.votes
         else:


### PR DESCRIPTION
During the `Leader rotation`, the previous leader isn't changed node type to peer and has collected vote of the last block that is made by itself. It makes be possible that two leaders exist.
That's why I edit logic like these:
- Doesn't broadcast a block after raising `TimeoutError`.
- Add logic to start the `leader_complaint_timer` into `channel_service.reset_leader()` and remove the logic from past places.
- Prevent to reset the `leader_complaint_timer` after receiving and voting of a duplicated block in `candidate blocks`.

And additional points:
- To prevent unnecessary verification, move a condition in `add_unconfirmed_block` for check state before verification of `unconfirmed block`.
- To prevent unnecessary broadcasting, stop broadcast an `unconfirmed block` after the timeout of limited vote time.
