### PR TITLE
[LC-567] add set_new_leader to peer_manager when blocksync ended

### DIFF
--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -59,7 +59,7 @@ class Epoch:
     @staticmethod
     def new_epoch(leader_id=None):
         block_manager = ObjectManager().channel_service.block_manager
-        leader_id = leader_id or ObjectManager().channel_service.block_manager.blockchain.get_next_leader()
+        leader_id = leader_id or ObjectManager().channel_service.block_manager.get_next_leader()
         return Epoch(block_manager, leader_id)
 
     def new_round(self, new_leader_id, round_=None):

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -139,6 +139,7 @@ class ChannelStateMachine(object):
         self.__channel_service.block_manager.update_service_status(status_code.Service.block_height_sync)
 
     def _blocksync_on_exit(self, *args, **kwargs):
+        self.__channel_service.set_new_leader()
         self.__channel_service.block_manager.stop_block_height_sync_timer()
         self.__channel_service.block_manager.update_service_status(status_code.Service.online)
 

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -102,7 +102,7 @@ class ConsensusSiever(ConsensusBase):
         self._blockchain.add_block(block, confirm_info=vote.votes)
         self._block_manager.candidate_blocks.remove_block(block.header.hash)
         self._blockchain.last_unconfirmed_block = None
-        next_leader = self._blockchain.get_next_leader()
+        next_leader = self._block_manager.get_next_leader()
         self._block_manager.epoch = Epoch.new_epoch(next_leader)
 
     def _makeup_new_block(self, block_version, complain_votes, block_hash):
@@ -220,7 +220,7 @@ class ConsensusSiever(ConsensusBase):
                 ObjectManager().channel_service.reset_leader(self._block_manager.epoch.leader_id)
                 ObjectManager().channel_service.turn_on_leader_complain_timer()
             else:
-                if self._blockchain.leader_made_block_count == (conf.MAX_MADE_BLOCK_COUNT - 1):
+                if self._blockchain.just_before_max_made_block_count:
                     # (conf.MAX_MADE_BLOCK_COUNT - 1) means if made_block_count is 9,
                     # next unconfirmed block height is 10
                     ObjectManager().channel_service.reset_leader(self._block_manager.epoch.leader_id)

--- a/loopchain/peermanager/peer_manager.py
+++ b/loopchain/peermanager/peer_manager.py
@@ -125,7 +125,7 @@ class PeerManager:
 
             # set to leader peer
             if not self._peer_list_data.leader_id or len(self.peer_list) == 0:
-                logging.debug("Set Group Leader Peer: " + str(peer.order))
+                logging.debug(f"Set Group Leader Peer: order({peer.order}), peer_id({peer.peer_id})")
                 self._peer_list_data.leader_id = peer.peer_id
 
             self.peer_list[peer.peer_id] = peer
@@ -143,7 +143,7 @@ class PeerManager:
 
         return False
 
-    def set_leader_peer(self, peer):
+    def set_leader_peer(self, peer: Peer):
         """리더 피어를 지정한다.
         없는 경우에는 전체 리더 피어를 지정하게 된다.
 
@@ -153,7 +153,7 @@ class PeerManager:
 
         if self.get_peer(peer.peer_id) is None:
             raise Exception(f'{peer.peer_id} is not a member of reps!')
-
+        logging.debug(f"set leader peer: {peer.peer_id}")
         self._peer_list_data.leader_id = peer.peer_id
 
     def get_leader_peer(self, is_peer=True) -> Optional[Peer]:

--- a/testcase/unittest/test_channel_statemachine.py
+++ b/testcase/unittest/test_channel_statemachine.py
@@ -23,8 +23,6 @@ from loopchain.protos import loopchain_pb2
 
 
 class MockBlockManager:
-    peer_type = loopchain_pb2.BLOCK_GENERATOR
-
     def __init__(self):
         self.timer_called = 0
         self.peer_type = loopchain_pb2.BLOCK_GENERATOR
@@ -49,23 +47,10 @@ class MockBlockManager:
         pass
 
 
-class MockBlockManagerCitizen:
-    peer_type = loopchain_pb2.PEER
-
-    def start_block_generate_timer(self):
-        pass
-
-    def block_height_sync(self):
-        pass
-
-    def stop_block_height_sync_timer(self):
-        pass
-
-    def update_service_status(self, status):
-        pass
-
-    def start_epoch(self):
-        pass
+class MockBlockManagerCitizen(MockBlockManager):
+    def __init__(self):
+        super().__init__()
+        self.peer_type = loopchain_pb2.PEER
 
 
 class MockChannelService:
@@ -93,6 +78,9 @@ class MockChannelService:
     def stop_shutdown_timer_when_fail_subscribe(self):
         pass
 
+    def set_new_leader(self):
+        pass
+
 
 class MockChannelServiceCitizen(MockChannelService):
     def __init__(self):
@@ -101,10 +89,6 @@ class MockChannelServiceCitizen(MockChannelService):
 
     def is_support_node_function(self, node_function):
         return False
-
-    # @property
-    # def block_manager(self):
-    #     return MockBlockManagerCitizen()
 
 
 class TestChannelStateMachine(unittest.TestCase):


### PR DESCRIPTION
add setting new leader when blocksync ended

- add set_new_leader in state_machine
- move get_next_leader from blockchain to block_manager
- update testcase in test_channelstatemachine