### PR TITLE
[LC-557] Keep order after penalty

### DIFF
--- a/conf/develop/iconservice_conf.json
+++ b/conf/develop/iconservice_conf.json
@@ -20,8 +20,11 @@
     "scorePackageValidator": false
   },
   "mainPRepCount": 4,
-  "mainAndSubPRepCount": 4,
+  "mainAndSubPRepCount": 8,
   "decentralizeTrigger": 0,
   "iissCalculatePeriod": 30,
-  "termPeriod": 30
+  "termPeriod": 30,
+  "penaltyGracePeriod": 30,
+  "blockValidationPenaltyThreshold": 10,
+  "lowProductivityPenaltyThreshold": 0
 }

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -31,7 +31,6 @@ from loopchain import utils
 from loopchain.baseservice import ObjectManager, TimerService, Timer
 from loopchain.blockchain import AnnounceNewBlockError
 from loopchain.blockchain.blocks import BlockSerializer, BlockVerifier
-from loopchain.blockchain.types import ExternalAddress
 from loopchain.blockchain.votes.v0_1a import BlockVotes
 from loopchain.channel.channel_property import ChannelProperty
 from loopchain.protos import message_code
@@ -180,15 +179,11 @@ class NodeSubscriber:
             block_verifier.invoke_func = blockchain.score_invoke
             reps_getter = blockchain.find_preps_addresses_by_roothash
             try:
-                next_leader = ObjectManager().channel_service.block_manager.get_next_leader()
-                if next_leader:
-                    next_leader = ExternalAddress.fromhex(next_leader)
                 block_verifier.verify(confirmed_block,
                                       blockchain.last_block,
                                       blockchain,
-                                      generator=blockchain.get_expected_generator(confirmed_block.header.peer_id),
-                                      reps_getter=reps_getter,
-                                      next_leader=next_leader)
+                                      generator=blockchain.get_expected_generator(confirmed_block),
+                                      reps_getter=reps_getter)
             except Exception as e:
                 self._exception = AnnounceNewBlockError(f"error: {type(e)}, message: {str(e)}")
             else:

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -31,6 +31,7 @@ from loopchain import utils
 from loopchain.baseservice import ObjectManager, TimerService, Timer
 from loopchain.blockchain import AnnounceNewBlockError
 from loopchain.blockchain.blocks import BlockSerializer, BlockVerifier
+from loopchain.blockchain.types import ExternalAddress
 from loopchain.blockchain.votes.v0_1a import BlockVotes
 from loopchain.channel.channel_property import ChannelProperty
 from loopchain.protos import message_code
@@ -179,12 +180,15 @@ class NodeSubscriber:
             block_verifier.invoke_func = blockchain.score_invoke
             reps_getter = blockchain.find_preps_addresses_by_roothash
             try:
+                next_leader = ObjectManager().channel_service.block_manager.get_next_leader()
+                if next_leader:
+                    next_leader = ExternalAddress.fromhex(next_leader)
                 block_verifier.verify(confirmed_block,
                                       blockchain.last_block,
                                       blockchain,
                                       generator=blockchain.get_expected_generator(confirmed_block.header.peer_id),
                                       reps_getter=reps_getter,
-                                      next_leader=ExternalAddress.fromhex(blockchain.get_next_leader()))
+                                      next_leader=next_leader)
             except Exception as e:
                 self._exception = AnnounceNewBlockError(f"error: {type(e)}, message: {str(e)}")
             else:

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -182,8 +182,9 @@ class NodeSubscriber:
                 block_verifier.verify(confirmed_block,
                                       blockchain.last_block,
                                       blockchain,
-                                      blockchain.get_expected_generator(confirmed_block.header.peer_id),
-                                      reps_getter=reps_getter)
+                                      generator=blockchain.get_expected_generator(confirmed_block.header.peer_id),
+                                      reps_getter=reps_getter,
+                                      next_leader=ExternalAddress.fromhex(blockchain.get_next_leader()))
             except Exception as e:
                 self._exception = AnnounceNewBlockError(f"error: {type(e)}, message: {str(e)}")
             else:

--- a/loopchain/baseservice/score_code.py
+++ b/loopchain/baseservice/score_code.py
@@ -24,9 +24,3 @@ class ScoreResponse(IntEnum):
     NOT_INVOKED = 2  # means pending
     NOT_EXIST = 3  # considered fail
     SCORE_CONTAINER_EXCEPTION = 9100
-
-
-# FIXME : remove
-class PrepChangedReason:
-    TERM_END = "0x0"  # Term ends and reset P-Rep list
-    PENALTY = "0x1"  # Updated within term (Penalty)

--- a/loopchain/baseservice/score_code.py
+++ b/loopchain/baseservice/score_code.py
@@ -26,6 +26,7 @@ class ScoreResponse(IntEnum):
     SCORE_CONTAINER_EXCEPTION = 9100
 
 
+# FIXME : remove
 class PrepChangedReason:
     TERM_END = "0x0"  # Term ends and reset P-Rep list
     PENALTY = "0x1"  # Updated within term (Penalty)

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -145,14 +145,14 @@ class BlockChain:
         utils.logger.debug(f"_keep_order_in_penalty() : keep_order = {keep_order}")
         return keep_order
 
-    def reset_leader_made_block_count(self):
+    def reset_leader_made_block_count(self, is_switched_role: bool = False):
         """Clear all made_block_counter
         FIXME : is func_name match to behavior?
 
         :return:
         """
         utils.logger.debug(f"reset_leader_made_block_count() : made_block_count = {self.__made_block_counter}")
-        if not self._keep_order_in_penalty():
+        if not self._keep_order_in_penalty() or is_switched_role:
             self.__made_block_counter.clear()
 
     def get_first_leader_of_next_reps(self, block: Block) -> str:
@@ -327,6 +327,8 @@ class BlockChain:
         prev_block = None
         if prev_hash in candidate_blocks.blocks.keys():
             prev_block = candidate_blocks.blocks[prev_hash].block
+            utils.logger.spam(
+                f"prev_block is None.({prev_block is None}) in candidate_blocks by prev_hash({prev_hash})")
 
         if not prev_block:
             prev_block = self.find_block_by_hash(prev_hash) or self.last_block

--- a/loopchain/blockchain/blocks/__init__.py
+++ b/loopchain/blockchain/blocks/__init__.py
@@ -1,4 +1,4 @@
-from .block import Block, BlockHeader, BlockBody, _dict__str__
+from .block import Block, BlockHeader, BlockBody, _dict__str__, NextRepsChangeReason
 from .block_builder import BlockBuilder
 from .block_serializer import BlockSerializer
 from .block_verifier import BlockVerifier

--- a/loopchain/blockchain/blocks/block.py
+++ b/loopchain/blockchain/blocks/block.py
@@ -14,6 +14,7 @@
 
 from collections import OrderedDict
 from dataclasses import dataclass, _FIELD, _FIELDS
+from enum import IntEnum
 from types import MappingProxyType
 from typing import Mapping
 
@@ -68,3 +69,24 @@ def _dict__str__(self: dict):
 BlockHeader.__str__ = _dataclass__str__
 BlockBody.__str__ = _dataclass__str__
 Block.__str__ = _dataclass__str__
+
+
+class NextRepsChangeReason(IntEnum):
+    NoChange = -1
+    TermEnd = 0
+    Penalty = 1
+
+    @classmethod
+    def convert_to_change_reason(cls, state: str) -> 'NextRepsChangeReason':
+        """Convert next_prep['state'] to NextRepsChangeReason
+
+        :param state: "0x0" is TermEnd,
+                      "0x1" is Penalty
+        :return: NextRepsChangeReason NoChange, TermEnd, Penalty
+        """
+
+        for reason in NextRepsChangeReason:
+            if reason.value == int(state, 16):
+                return reason
+
+        return NextRepsChangeReason.NoChange

--- a/loopchain/blockchain/blocks/block_verifier.py
+++ b/loopchain/blockchain/blocks/block_verifier.py
@@ -19,7 +19,6 @@ from loopchain import configure as conf
 from loopchain import utils
 from loopchain.blockchain.exception import BlockVersionNotMatch, TransactionOutOfTimeBound
 from loopchain.blockchain.transactions import TransactionVerifier
-from loopchain.blockchain.types import ExternalAddress
 from loopchain.crypto.signature import SignVerifier
 
 if TYPE_CHECKING:

--- a/loopchain/blockchain/blocks/v0_1a/block.py
+++ b/loopchain/blockchain/blocks/v0_1a/block.py
@@ -47,6 +47,8 @@ class BlockHeader(BaseBlockHeader):
 
     @property
     def prep_changed_reason(self) -> None:
+        """If the block version doesn't support this, it should return None.
+        """
         return None
 
     @property

--- a/loopchain/blockchain/blocks/v0_1a/block.py
+++ b/loopchain/blockchain/blocks/v0_1a/block.py
@@ -40,9 +40,13 @@ class BlockHeader(BaseBlockHeader):
         return self.peer_id == self.next_leader and self.merkle_tree_root_hash == Hash32(bytes(32))
 
     @property
-    def prep_changed(self) -> None:
-        """If the block version doesn't support this, it should return None.
+    def prep_changed(self) -> bool:
+        """If the block version doesn't support this, it should return False.
         """
+        return False
+
+    @property
+    def prep_changed_reason(self) -> None:
         return None
 
     @property

--- a/loopchain/blockchain/blocks/v0_1a/block_verifier.py
+++ b/loopchain/blockchain/blocks/v0_1a/block_verifier.py
@@ -14,7 +14,9 @@ if TYPE_CHECKING:
 class BlockVerifier(BaseBlockVerifier):
     version = BlockHeader.version
 
-    def _verify_common(self, block: 'Block', prev_block: 'Block', generator: 'ExternalAddress'=None, **kwargs):
+    def _verify_common(self, block: 'Block', prev_block: 'Block', **kwargs):
+        generator: 'ExternalAddress' = kwargs.get("generator")
+
         header: BlockHeader = block.header
         body: BlockBody = block.body
 

--- a/loopchain/blockchain/blocks/v0_3/__init__.py
+++ b/loopchain/blockchain/blocks/v0_3/__init__.py
@@ -1,4 +1,4 @@
-from .block import BlockHeader, BlockBody, receipts_hash_generator
+from .block import BlockHeader, BlockBody, NextRepsChangeReason, receipts_hash_generator
 from .block_prover import BlockProver
 from .block_builder import BlockBuilder
 from .block_serializer import BlockSerializer

--- a/loopchain/blockchain/blocks/v0_3/__init__.py
+++ b/loopchain/blockchain/blocks/v0_3/__init__.py
@@ -1,4 +1,4 @@
-from .block import BlockHeader, BlockBody, NextRepsChangeReason, receipts_hash_generator
+from .block import BlockHeader, BlockBody, receipts_hash_generator
 from .block_prover import BlockProver
 from .block_builder import BlockBuilder
 from .block_serializer import BlockSerializer

--- a/loopchain/blockchain/blocks/v0_3/block.py
+++ b/loopchain/blockchain/blocks/v0_3/block.py
@@ -1,18 +1,11 @@
 from dataclasses import dataclass
-from enum import IntEnum
 from typing import List, Optional
 
 from loopchain.blockchain.blocks import (BlockHeader as BaseBlockHeader,
-                                         BlockBody as BaseBlockBody)
+                                         BlockBody as BaseBlockBody, NextRepsChangeReason)
 from loopchain.blockchain.types import Hash32, ExternalAddress, BloomFilter
 from loopchain.blockchain.votes.v0_3 import BlockVote, LeaderVote
 from loopchain.crypto.hashing import build_hash_generator
-
-
-class NextRepsChangeReason(IntEnum):
-    NoChange = -1
-    TermEnd = 0
-    Penalty = 1
 
 
 @dataclass(frozen=True)
@@ -44,14 +37,15 @@ class BlockHeader(BaseBlockHeader):
 
     @property
     def prep_changed_reason(self) -> Optional[NextRepsChangeReason]:
+        """Return prep changed reason
 
-        if not self.prep_changed:
+        :return: NextRepsChangeReason : NoChange, TermEnd, Penalty
+        """
+        if not self.prep_changed and not self.is_unrecorded:
             return NextRepsChangeReason.NoChange
 
-        if self.next_leader == ExternalAddress.empty():
-            return NextRepsChangeReason.TermEnd
-
-        return NextRepsChangeReason.Penalty
+        # block v0.3 work as TermEnd when Penalty
+        return NextRepsChangeReason.TermEnd
 
     @property
     def is_unrecorded(self) -> bool:

--- a/loopchain/blockchain/blocks/v0_3/block_builder.py
+++ b/loopchain/blockchain/blocks/v0_3/block_builder.py
@@ -1,4 +1,5 @@
 import time
+from enum import IntEnum
 from functools import reduce
 from operator import or_
 from typing import List
@@ -19,14 +20,16 @@ class BlockBuilder(BaseBlockBuilder):
 
         # Attributes that must be assigned
         self.reps: List[ExternalAddress] = None
+        self.next_reps: List[ExternalAddress] = None
         self.next_reps_hash: Hash32 = None
+        self.next_reps_change_reason = NextRepsChangeReason.NoChange
         self.leader_votes: List[LeaderVote] = []
         self.prev_votes: List[BlockVote] = None
-        self.next_leader: 'ExternalAddress' = None
 
         # Attributes to be assigned(optional)
         self.fixed_timestamp: int = None
         self.state_hash: 'Hash32' = None
+        self.next_leader: 'ExternalAddress' = None
 
         # Attributes to be generated
         self.transactions_hash: 'Hash32' = None
@@ -128,19 +131,44 @@ class BlockBuilder(BaseBlockBuilder):
         return block_prover.get_proof_root()
 
     def build_reps_hash(self):
-        try:
-            if self.reps_hash is not None:
-                return self.reps_hash
-
-            self.reps_hash = self._build_reps_hash()
+        if self.reps_hash is not None:
             return self.reps_hash
-        finally:
-            if self.next_reps_hash is None:
-                self.next_reps_hash = self.reps_hash
+
+        self.reps_hash = self._build_reps_hash()
+        return self.reps_hash
 
     def _build_reps_hash(self):
         block_prover = BlockProver((rep.extend() for rep in self.reps), BlockProverType.Rep)
         return block_prover.get_proof_root()
+
+    def build_next_reps_hash(self):
+        if self.next_reps_hash is not None:
+            return self.next_reps_hash
+
+        self.next_reps_hash = self._build_next_reps_hash()
+        return self.next_reps_hash
+
+    def _build_next_reps_hash(self):
+        block_prover = BlockProver((rep.extend() for rep in self.next_reps), BlockProverType.Rep)
+        return block_prover.get_proof_root()
+
+    def build_next_leader(self):
+        if self.next_leader is not None:
+            return self.next_leader
+
+        self.next_leader = self._build_next_leader()
+        return self.next_leader
+
+    def _build_next_leader(self):
+        if self.next_reps_change_reason == NextRepsChangeReason.Term:
+            return self.next_reps[0]
+        elif self.next_reps_change_reason == NextRepsChangeReason.Update:
+            curr_index = self.reps.index(self.peer_id)
+            next_index = curr_index + 1
+            next_index = next_index if next_index < len(self.next_reps) else 0
+            return self.next_reps[next_index]
+        else:
+            return self.next_leader
 
     def build_leader_votes_hash(self):
         if self.leader_votes_hash is not None:
@@ -194,6 +222,8 @@ class BlockBuilder(BaseBlockBuilder):
         self.build_transactions_hash()
         self.build_receipts_hash()
         self.build_reps_hash()
+        self.build_next_reps_hash()
+        self.build_next_leader()
         self.build_leader_votes_hash()
         self.build_prev_votes_hash()
         self.build_logs_bloom()
@@ -244,3 +274,9 @@ class BlockBuilder(BaseBlockBuilder):
         body: BlockBody = block.body
         self.leader_votes = body.leader_votes
         self.prev_votes = body.prev_votes
+
+
+class NextRepsChangeReason(IntEnum):
+    NoChange = -1
+    Term = 0
+    Update = 1

--- a/loopchain/blockchain/blocks/v0_3/block_builder.py
+++ b/loopchain/blockchain/blocks/v0_3/block_builder.py
@@ -6,7 +6,7 @@ from typing import List
 from loopchain.blockchain.types import ExternalAddress, Hash32, BloomFilter
 from loopchain.blockchain.transactions import TransactionVersioner
 from loopchain.blockchain.blocks import Block, BlockBuilder as BaseBlockBuilder, BlockProverType
-from loopchain.blockchain.blocks.v0_3 import BlockHeader, BlockBody, BlockProver, NextRepsChangeReason
+from loopchain.blockchain.blocks.v0_3 import BlockHeader, BlockBody, BlockProver
 from loopchain.blockchain.votes.v0_3 import BlockVote, LeaderVote
 
 
@@ -20,17 +20,14 @@ class BlockBuilder(BaseBlockBuilder):
 
         # Attributes that must be assigned
         self.reps: List[ExternalAddress] = None
-        self.next_reps: List[ExternalAddress] = None
         self.next_reps_hash: Hash32 = None
-        self.next_reps_change_reason: NextRepsChangeReason = NextRepsChangeReason.NoChange
         self.leader_votes: List[LeaderVote] = []
         self.prev_votes: List[BlockVote] = None
+        self.next_leader: 'ExternalAddress' = None
 
         # Attributes to be assigned(optional)
         self.fixed_timestamp: int = None
         self.state_hash: 'Hash32' = None
-        self.next_leader: 'ExternalAddress' = None
-        self.is_max_made_block_count: bool = None
 
         # Attributes to be generated
         self.transactions_hash: 'Hash32' = None
@@ -132,47 +129,19 @@ class BlockBuilder(BaseBlockBuilder):
         return block_prover.get_proof_root()
 
     def build_reps_hash(self):
-        if self.reps_hash is not None:
-            return self.reps_hash
+        try:
+            if self.reps_hash is not None:
+                return self.reps_hash
 
-        self.reps_hash = self._build_reps_hash()
-        return self.reps_hash
+            self.reps_hash = self._build_reps_hash()
+            return self.reps_hash
+        finally:
+            if self.next_reps_hash is None:
+                self.next_reps_hash = self.reps_hash
 
     def _build_reps_hash(self):
         block_prover = BlockProver((rep.extend() for rep in self.reps), BlockProverType.Rep)
         return block_prover.get_proof_root()
-
-    def build_next_reps_hash(self):
-        if self.next_reps_hash is not None:
-            return self.next_reps_hash
-
-        self.next_reps_hash = self._build_next_reps_hash()
-        return self.next_reps_hash
-
-    def _build_next_reps_hash(self):
-        block_prover = BlockProver((rep.extend() for rep in self.next_reps), BlockProverType.Rep)
-        return block_prover.get_proof_root()
-
-    def build_next_leader(self):
-        if self.next_leader is not None:
-            return self.next_leader
-
-        self.next_leader = self._build_next_leader()
-        return self.next_leader
-
-    def _build_next_leader(self):
-        if self.next_reps_change_reason is NextRepsChangeReason.TermEnd:
-            return ExternalAddress.empty()
-        elif self.next_reps_change_reason is NextRepsChangeReason.Penalty:
-            if not self.is_max_made_block_count and self.peer_id in self.next_reps:
-                next_index = self.reps.index(self.peer_id)
-            else:
-                curr_index = self.reps.index(self.peer_id)
-                next_index = curr_index + 1
-                next_index = next_index if next_index < len(self.next_reps) else 0
-            return self.next_reps[next_index]
-        else:
-            return self.next_leader
 
     def build_leader_votes_hash(self):
         if self.leader_votes_hash is not None:
@@ -226,8 +195,6 @@ class BlockBuilder(BaseBlockBuilder):
         self.build_transactions_hash()
         self.build_receipts_hash()
         self.build_reps_hash()
-        self.build_next_reps_hash()
-        self.build_next_leader()
         self.build_leader_votes_hash()
         self.build_prev_votes_hash()
         self.build_logs_bloom()

--- a/loopchain/blockchain/blocks/v0_3/block_verifier.py
+++ b/loopchain/blockchain/blocks/v0_3/block_verifier.py
@@ -16,8 +16,8 @@
 from typing import TYPE_CHECKING, Callable, Sequence
 
 from loopchain import configure as conf
-from loopchain.blockchain.blocks import BlockVerifier as BaseBlockVerifier, BlockBuilder
-from loopchain.blockchain.blocks.v0_3 import BlockHeader, BlockBody
+from loopchain.blockchain.blocks import BlockVerifier as BaseBlockVerifier
+from loopchain.blockchain.blocks.v0_3 import BlockHeader, BlockBody, BlockBuilder
 from loopchain.blockchain.exception import NotInReps
 from loopchain.blockchain.types import ExternalAddress, Hash32
 from loopchain.blockchain.votes.v0_3 import BlockVotes, LeaderVotes
@@ -29,9 +29,19 @@ if TYPE_CHECKING:
 class BlockVerifier(BaseBlockVerifier):
     version = BlockHeader.version
 
+    def verify(self, block: 'Block', prev_block: 'Block', blockchain=None, **kwargs):
+        # To make sure that next_leader always exists in kwargs
+        next_leader = kwargs.pop('next_leader')
+        super().verify(block, prev_block, blockchain, next_leader=next_leader, **kwargs)
+
+    def verify_loosely(self, block: 'Block', prev_block: 'Block', blockchain=None, **kwargs):
+        kwargs.pop('next_leader', None)
+        super().verify_loosely(block, prev_block, blockchain, **kwargs)
+
     # noinspection PyMethodOverriding
-    def _verify_common(self, block: 'Block', prev_block: 'Block', generator: 'ExternalAddress'=None, *,
-                       reps_getter: Callable[[Sequence[ExternalAddress]], Hash32]):
+    def _verify_common(self, block: 'Block', prev_block: 'Block', *,
+                       reps_getter: Callable[[Sequence[ExternalAddress]], Hash32], next_leader: 'ExternalAddress'=None,
+                       **kwargs):
         header: BlockHeader = block.header
         body: BlockBody = block.body
 
@@ -69,7 +79,7 @@ class BlockVerifier(BaseBlockVerifier):
 
         invoke_result = None
         if self.invoke_func:
-            self.verify_invoke(builder, block, prev_block)
+            invoke_result = self.verify_invoke(builder, block, prev_block, next_leader)
 
         builder.build_transactions_hash()
         if header.transactions_hash != builder.transactions_hash:
@@ -101,15 +111,21 @@ class BlockVerifier(BaseBlockVerifier):
                                      f"builder({builder.build_block_header_data()}).")
             self._handle_exception(exception)
 
-        if generator:
-            self.verify_generator(block, generator)
-
         return invoke_result
 
-    def verify_invoke(self, builder: 'BlockBuilder', block: 'Block', prev_block: 'Block'):
+    def verify_invoke(self, builder: 'BlockBuilder', block: 'Block', prev_block: 'Block',
+                      next_leader: 'ExternalAddress'=None) -> dict:
         new_block, invoke_result = self.invoke_func(block, prev_block)
         header: BlockHeader = block.header
         new_header: BlockHeader = new_block.header
+
+        if (header.next_leader != ExternalAddress.empty() and
+                next_leader and next_leader != header.next_leader):
+            exception = RuntimeError(f"Block({header.height}, {header.hash.hex()}, "
+                                     f"NextLeader({header.next_leader}), "
+                                     f"Expected({next_leader}).")
+            self._handle_exception(exception)
+
         if header.state_hash != new_header.state_hash:
             exception = RuntimeError(f"Block({header.height}, {header.hash.hex()}, "
                                      f"StateRootHash({header.state_hash}), "
@@ -117,6 +133,7 @@ class BlockVerifier(BaseBlockVerifier):
             self._handle_exception(exception)
 
         if header.next_reps_hash != new_header.next_reps_hash:
+            # FIXME : need review this condition!
             if (not new_header.prep_changed
                     and header.next_reps_hash == new_header.revealed_next_reps_hash):
                 pass
@@ -128,6 +145,12 @@ class BlockVerifier(BaseBlockVerifier):
                                          f"\norigin header({header}), "
                                          f"\nnew block header({new_header}).")
                 self._handle_exception(exception)
+
+        if header.next_leader != new_header.next_leader:
+            exception = RuntimeError(f"Block({header.height}, {header.hash.hex()}, "
+                                     f"NextLeader({header.next_leader}), "
+                                     f"Expected({new_header.next_leader}).")
+            self._handle_exception(exception)
 
         builder.state_hash = new_header.state_hash
         builder.receipts = invoke_result
@@ -146,14 +169,9 @@ class BlockVerifier(BaseBlockVerifier):
                                      f"Expected({builder.logs_bloom.hex()}).")
             self._handle_exception(exception)
 
-    def verify_generator(self, block: 'Block', generator: 'ExternalAddress'):
-        if not block.header.complained and block.header.peer_id != generator:
-            exception = RuntimeError(f"Block({block.header.height}, {block.header.hash.hex()}, "
-                                     f"Generator({block.header.peer_id.hex_xx()}), "
-                                     f"Expected({generator.hex_xx()}).")
-            self._handle_exception(exception)
+        return invoke_result
 
-    def verify_leader_votes(self, block: 'Block', prev_block: 'Block',  reps: Sequence[ExternalAddress]):
+    def verify_leader_votes(self, block: 'Block', prev_block: 'Block', reps: Sequence[ExternalAddress]):
         body: BlockBody = block.body
         if body.leader_votes:
             any_vote = next(vote for vote in body.leader_votes if vote)

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -272,9 +272,9 @@ class ChannelService:
             ChannelProperty().node_type = new_node_type
         self.__inner_service.update_sub_services_properties(node_type=ChannelProperty().node_type.value)
 
-    def switch_role(self, force: bool=False):
+    def switch_role(self):
         self.peer_manager.update_all_peers()
-        if force or self._is_role_switched():
+        if self._is_role_switched():
             self.__state_machine.switch_role()
 
     async def reset_network(self):

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -23,7 +23,7 @@ import loopchain.utils as util
 from loopchain import configure as conf
 from loopchain.blockchain import UnrecordedBlock, InvalidUnconfirmedBlock
 from loopchain.blockchain.blocks import Block
-from loopchain.peer import status_code, ChannelProperty
+from loopchain.peer import status_code
 from loopchain.protos import loopchain_pb2
 from loopchain.statemachine import statemachine
 from loopchain.utils import loggers

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -27,11 +27,12 @@ from loopchain.baseservice import TimerService, ObjectManager, Timer, RestMethod
 from loopchain.baseservice.aging_cache import AgingCache
 from loopchain.blockchain import BlockChain, CandidateBlocks, Epoch, BlockchainError, NID, exception
 from loopchain.blockchain.blocks import Block, BlockVerifier, BlockSerializer
-from loopchain.blockchain.exception import ConfirmInfoInvalid, ConfirmInfoInvalidAddedBlock, \
-    TransactionOutOfTimeBound, NotInReps, NotReadyToConfirmInfo, UnrecordedBlock, UnexpectedLeader
+from loopchain.blockchain.blocks.v0_3 import NextRepsChangeReason
+from loopchain.blockchain.exception import (ConfirmInfoInvalid, ConfirmInfoInvalidAddedBlock,
+                                            TransactionOutOfTimeBound, NotInReps,
+                                            NotReadyToConfirmInfo,UnrecordedBlock, UnexpectedLeader)
 from loopchain.blockchain.exception import ConfirmInfoInvalidNeedBlockSync, TransactionDuplicatedHashError
-from loopchain.blockchain.exception import InvalidUnconfirmedBlock, DuplicationUnconfirmedBlock, \
-    ScoreInvokeError
+from loopchain.blockchain.exception import InvalidUnconfirmedBlock, DuplicationUnconfirmedBlock, ScoreInvokeError
 from loopchain.blockchain.transactions import Transaction, TransactionSerializer, v2, v3
 from loopchain.blockchain.types import ExternalAddress
 from loopchain.blockchain.types import TransactionStatusInQueue, Hash32
@@ -674,7 +675,7 @@ class BlockManager:
 
         block = self.blockchain.last_block
 
-        if block.header.prep_changed:
+        if block.header.prep_changed and block.header.prep_changed_reason is NextRepsChangeReason.TermEnd:
             next_leader = self.blockchain.get_first_leader_of_next_reps(block)
         elif self.blockchain.made_block_count_reached_max(block):
             reps_hash = (block.header.revealed_next_reps_hash
@@ -882,7 +883,7 @@ class BlockManager:
                                                                       reps_hash=reps_hash)
 
     def vote_unconfirmed_block(self, block: Block, round_: int, is_validated):
-        logging.debug(f"block_manager:vote_unconfirmed_block ({self.channel_name}/{is_validated})")
+        logging.debug(f"vote_unconfirmed_block() ({self.channel_name}/{is_validated})")
 
         vote = BlockVote.new(
             signer=ChannelProperty().peer_auth,
@@ -956,12 +957,16 @@ class BlockManager:
 
             util.logger.debug(f"unconfirmed_block.header({unconfirmed_block.header})")
 
+            next_leader = self.get_next_leader()
+            if next_leader:
+                next_leader = ExternalAddress.fromhex(next_leader)
+
             block_verifier.verify(unconfirmed_block,
                                   self.blockchain.last_block,
                                   self.blockchain,
                                   generator=self.blockchain.get_expected_generator(unconfirmed_block.header.peer_id),
                                   reps_getter=reps_getter,
-                                  next_leader=ExternalAddress.fromhex(self.blockchain.get_next_leader()))
+                                  next_leader=next_leader)
         except NotInReps as e:
             util.logger.debug(f"in _vote Not In Reps({e}) state({self.__channel_service.state_machine.state})")
         except Exception as e:

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -290,7 +290,7 @@ class BlockManager:
             if expected_leader != block_header.peer_id.hex_hx():
                 raise UnexpectedLeader(
                     f"The unconfirmed block is made by an unexpected leader. "
-                    f"Expected({self.epoch.leader_id}), Unconfirmed_block({block_header.peer_id.hex_hx()})")
+                    f"Expected({expected_leader}), Unconfirmed_block({block_header.peer_id.hex_hx()})")
 
         if current_state == 'LeaderComplain' and self.epoch.leader_id == block_header.peer_id.hex_hx():
             raise InvalidUnconfirmedBlock(f"The unconfirmed block is made by complained leader.\n{block_header})")
@@ -934,6 +934,7 @@ class BlockManager:
         prev_block = self.blockchain.get_prev_block(unconfirmed_block)
         reps_getter = self.blockchain.find_preps_addresses_by_roothash
 
+        util.logger.spam(f"prev_block: {prev_block.header.hash if prev_block else None}")
         if not prev_block:
             raise NotReadyToConfirmInfo(
                 "There is no prev block or not ready to confirm block (Maybe node is starting)")

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -959,8 +959,9 @@ class BlockManager:
             block_verifier.verify(unconfirmed_block,
                                   self.blockchain.last_block,
                                   self.blockchain,
-                                  self.blockchain.get_expected_generator(unconfirmed_block.header.peer_id),
-                                  reps_getter=reps_getter)
+                                  generator=self.blockchain.get_expected_generator(unconfirmed_block.header.peer_id),
+                                  reps_getter=reps_getter,
+                                  next_leader=ExternalAddress.fromhex(self.blockchain.get_next_leader()))
         except NotInReps as e:
             util.logger.debug(f"in _vote Not In Reps({e}) state({self.__channel_service.state_machine.state})")
         except Exception as e:

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -93,6 +93,9 @@ class ConsensusSiever(ConsensusBase):
             block_builder.next_leader = ExternalAddress.fromhex_address(self._block_manager.epoch.leader_id)
             block_builder.reps = self._block_manager.epoch.reps
 
+        # to build temporary block
+        block_builder.next_reps = []
+
         return block_builder.build()
 
     async def __add_block(self, block: Block):

--- a/loopchain/peermanager/peer_manager.py
+++ b/loopchain/peermanager/peer_manager.py
@@ -21,6 +21,8 @@ from loopchain.baseservice import ObjectManager
 from loopchain.blockchain.blocks import BlockProverType
 from loopchain.blockchain.blocks.v0_3 import BlockProver
 from loopchain.blockchain.types import ExternalAddress, Hash32
+from loopchain.channel.channel_property import ChannelProperty
+from loopchain.configure_default import NodeType
 from loopchain.peermanager import Peer, PeerLoader, PeerListData
 
 
@@ -117,7 +119,10 @@ class PeerManager:
             peer = Peer(rep_info["id"], rep_info["p2pEndpoint"], order=order)
             self.add_peer(peer)
 
-        blockchain.reset_leader_made_block_count()
+        new_reps = blockchain.find_preps_addresses_by_roothash(Hash32.fromhex(reps_hash, ignore_prefix=True))
+        new_node_type = NodeType.CommunityNode if ChannelProperty().peer_address in new_reps else NodeType.CitizenNode
+        is_switched_role = new_node_type != ChannelProperty().node_type
+        blockchain.reset_leader_made_block_count(is_switched_role)
 
     def update_all_peers(self):
         if self._reps_reset_data:

--- a/testcase/unittest/blocks/test_block_pytest.py
+++ b/testcase/unittest/blocks/test_block_pytest.py
@@ -3,7 +3,8 @@ import os
 import pytest
 
 from loopchain.blockchain.blocks.v0_1a.block import BlockHeader as BlockHeader_v0_1a
-from loopchain.blockchain.blocks.v0_3.block import BlockHeader as BlockHeader_v0_3, NextRepsChangeReason
+from loopchain.blockchain.blocks.v0_3.block import BlockHeader as BlockHeader_v0_3
+from loopchain.blockchain.blocks.block import NextRepsChangeReason
 from loopchain.blockchain.types import Address, Signature, Hash32, ExternalAddress, BloomFilter
 
 
@@ -88,4 +89,4 @@ class TestBlockHeader_v0_3:
                                 next_reps_hash=Hash32(os.urandom(Hash32.size)))
 
         assert header.prep_changed
-        assert header.prep_changed_reason == NextRepsChangeReason.Penalty
+        assert header.prep_changed_reason == NextRepsChangeReason.TermEnd

--- a/testcase/unittest/blocks/test_block_pytest.py
+++ b/testcase/unittest/blocks/test_block_pytest.py
@@ -2,9 +2,8 @@ import os
 
 import pytest
 
-from loopchain.baseservice.score_code import PrepChangedReason
 from loopchain.blockchain.blocks.v0_1a.block import BlockHeader as BlockHeader_v0_1a
-from loopchain.blockchain.blocks.v0_3.block import BlockHeader as BlockHeader_v0_3
+from loopchain.blockchain.blocks.v0_3.block import BlockHeader as BlockHeader_v0_3, NextRepsChangeReason
 from loopchain.blockchain.types import Address, Signature, Hash32, ExternalAddress, BloomFilter
 
 
@@ -80,11 +79,13 @@ class TestBlockHeader_v0_3:
                                 reps_hash=Hash32(os.urandom(Hash32.size)),
                                 next_reps_hash=Hash32(os.urandom(Hash32.size)))
 
-        assert header.prep_changed == PrepChangedReason.TERM_END
+        assert header.prep_changed
+        assert header.prep_changed_reason is NextRepsChangeReason.TermEnd
 
     def test_prep_changed_by_penalty_if_exists_next_reps_hash_and_next_leader(self, header_factory):
         header = header_factory(next_leader=ExternalAddress(os.urandom(ExternalAddress.size)),
                                 reps_hash=Hash32(os.urandom(Hash32.size)),
                                 next_reps_hash=Hash32(os.urandom(Hash32.size)))
 
-        assert header.prep_changed == PrepChangedReason.PENALTY
+        assert header.prep_changed
+        assert header.prep_changed_reason == NextRepsChangeReason.Penalty

--- a/testcase/unittest/test_block.py
+++ b/testcase/unittest/test_block.py
@@ -246,13 +246,16 @@ class TestBlock(unittest.TestCase):
                 "tx_dumped": tx_serializer.to_full_data(tx)
             }
 
+        next_leader = ExternalAddress.fromhex("hx00112233445566778899aabbccddeeff00112233")
+
         block_builder.signer = test_signer
         block_builder.height = 0
         block_builder.prev_hash = Hash32(bytes(Hash32.size))
         block_builder.state_hash = Hash32(bytes(Hash32.size))
         block_builder.receipts = dummy_receipts
         block_builder.reps = [ExternalAddress.fromhex_address(test_signer.address)]
-        block_builder.next_leader = ExternalAddress.fromhex("hx00112233445566778899aabbccddeeff00112233")
+        block_builder.next_leader = next_leader
+        block_builder.next_reps = []
 
         vote = BlockVote.new(test_signer, utils.get_time_stamp(), block_builder.height - 1, 0, block_builder.prev_hash)
         votes = BlockVotes(block_builder.reps, conf.VOTING_RATIO, block_builder.height - 1, 0, block_builder.prev_hash)
@@ -264,7 +267,7 @@ class TestBlock(unittest.TestCase):
 
         block_verifier.invoke_func = lambda b, prev_b: (block, dummy_receipts)
         reps_getter = lambda _: block_builder.reps
-        block_verifier.verify(block, None, None, block.header.peer_id, reps_getter=reps_getter)
+        block_verifier.verify(block, None, None, reps_getter=reps_getter, next_leader=next_leader)
 
         block_serializer = BlockSerializer.new("0.3", tx_versioner)
         block_serialized = block_serializer.serialize(block)

--- a/testcase/unittest/test_block.py
+++ b/testcase/unittest/test_block.py
@@ -267,7 +267,8 @@ class TestBlock(unittest.TestCase):
 
         block_verifier.invoke_func = lambda b, prev_b: (block, dummy_receipts)
         reps_getter = lambda _: block_builder.reps
-        block_verifier.verify(block, None, None, reps_getter=reps_getter, next_leader=next_leader)
+        generator = ExternalAddress.fromhex_address(test_signer.address)
+        block_verifier.verify(block, None, None, generator=generator, reps_getter=reps_getter)
 
         block_serializer = BlockSerializer.new("0.3", tx_versioner)
         block_serialized = block_serializer.serialize(block)


### PR DESCRIPTION
Keep order after penalty
- Add `build_next_leader`
- Add `build_next_reps_hash`
- maintain leader and made_block_count when leader no need to change in penalty
- keep order after penalty will work on block version `0.4`