### PR TITLE
[LC-582] Set block header attributes according to P-Rep list status.

### DIFF
--- a/conf/develop/iconservice_conf.json
+++ b/conf/develop/iconservice_conf.json
@@ -22,6 +22,6 @@
   "mainPRepCount": 4,
   "mainAndSubPRepCount": 4,
   "decentralizeTrigger": 0,
-  "iissCalculatePeriod": 10,
-  "termPeriod": 10
+  "iissCalculatePeriod": 15,
+  "termPeriod": 15
 }

--- a/loopchain/baseservice/lru_cache.py
+++ b/loopchain/baseservice/lru_cache.py
@@ -6,7 +6,7 @@ from functools import wraps
 from inspect import signature
 
 
-def lru_cache(maxsize=None, not_none_returns_only=False):
+def lru_cache(maxsize=None, valued_returns_only=False):
     def decorator(func):
         func_sig = signature(func)
         cache = OrderedDict()
@@ -21,7 +21,7 @@ def lru_cache(maxsize=None, not_none_returns_only=False):
                 val = cache[key]
             except KeyError:
                 val = func(*args, **kwargs)
-                if not_none_returns_only and val is None:
+                if valued_returns_only and not val:
                     pass
                 else:
                     cache[key] = val

--- a/loopchain/baseservice/score_code.py
+++ b/loopchain/baseservice/score_code.py
@@ -28,4 +28,4 @@ class ScoreResponse(IntEnum):
 
 class PrepChangedReason:
     TERM_END = "0x0"  # Term ends and reset P-Rep list
-    PANELTY = "0x1"  # Updated within term (Panelty)
+    PENALTY = "0x1"  # Updated within term (Penalty)

--- a/loopchain/baseservice/score_code.py
+++ b/loopchain/baseservice/score_code.py
@@ -24,3 +24,8 @@ class ScoreResponse(IntEnum):
     NOT_INVOKED = 2  # means pending
     NOT_EXIST = 3  # considered fail
     SCORE_CONTAINER_EXCEPTION = 9100
+
+
+class PrepChangedReason:
+    TERM_END = "0x0"  # Term ends and reset P-Rep list
+    PANELTY = "0x1"  # Updated within term (Panelty)

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -1139,7 +1139,8 @@ class BlockChain:
             ObjectManager().channel_service.peer_manager.reset_all_peers(
                 next_prep["rootHash"], next_prep['preps'], update_now=False)
         else:
-            next_preps_hash = None
+            # P-Rep list has no changes
+            next_preps_hash = Hash32.empty()
 
         if prev_block.header.version != "0.1a":
             reps = self.find_preps_addresses_by_roothash(_block.header.reps_hash)

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -363,12 +363,12 @@ class BlockChain:
             return json.dumps(votes_serialized).encode(encoding='UTF-8')
         return bytes()
 
-    @lru_cache(maxsize=4, not_none_returns_only=True)
+    @lru_cache(maxsize=4, valued_returns_only=True)
     def find_preps_ids_by_roothash(self, roothash: Hash32) -> List[str]:
         preps = self.find_preps_by_roothash(roothash)
         return [prep["id"] for prep in preps]
 
-    @lru_cache(maxsize=4, not_none_returns_only=True)
+    @lru_cache(maxsize=4, valued_returns_only=True)
     def find_preps_addresses_by_roothash(self, roothash: Hash32) -> List[ExternalAddress]:
         preps_ids = self.find_preps_ids_by_roothash(roothash)
         return [ExternalAddress.fromhex(prep_id) for prep_id in preps_ids]
@@ -551,8 +551,9 @@ class BlockChain:
             self._write_tx(block, receipts, batch)
 
         if next_prep:
-            utils.logger.spam(f"store next_prep in __write_block_data\nprep_hash({next_prep['rootHash']})"
-                              f"\npreps({next_prep['preps']})")
+            utils.logger.spam(
+                f"store next_prep in __write_block_data\nprep_hash({next_prep['rootHash']})"
+                f"\npreps({next_prep['preps']})")
             self.write_preps(Hash32.fromhex(next_prep['rootHash'], ignore_prefix=True), next_prep['preps'], batch)
 
         if confirm_info:

--- a/loopchain/blockchain/blocks/block.py
+++ b/loopchain/blockchain/blocks/block.py
@@ -1,9 +1,24 @@
+# Copyright 2019 ICON Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from collections import OrderedDict
 from dataclasses import dataclass, _FIELD, _FIELDS
 from types import MappingProxyType
 from typing import Mapping
-from loopchain.blockchain.types import Hash32, ExternalAddress, Signature
+
 from loopchain.blockchain.transactions import Transaction
+from loopchain.blockchain.types import Hash32, ExternalAddress, Signature
 
 
 @dataclass(frozen=True)

--- a/loopchain/blockchain/blocks/v0_1a/block.py
+++ b/loopchain/blockchain/blocks/v0_1a/block.py
@@ -29,6 +29,14 @@ class BlockHeader(BaseBlockHeader):
             object.__setattr__(self, "commit_state", commit_state)
 
     @property
+    def reps_hash(self) -> None:
+        """0.1a block doesn't support this.
+
+        :return: Always None
+        """
+        return None
+
+    @property
     def complained(self) -> bool:
         # tx == 0 and peer_id == next_leader >> complained = True
         return self.peer_id == self.next_leader and self.merkle_tree_root_hash == Hash32(bytes(32))

--- a/loopchain/blockchain/blocks/v0_1a/block.py
+++ b/loopchain/blockchain/blocks/v0_1a/block.py
@@ -30,9 +30,7 @@ class BlockHeader(BaseBlockHeader):
 
     @property
     def reps_hash(self) -> None:
-        """0.1a block doesn't support this.
-
-        :return: Always None
+        """If the block version doesn't support this, it should return None.
         """
         return None
 
@@ -43,17 +41,13 @@ class BlockHeader(BaseBlockHeader):
 
     @property
     def prep_changed(self) -> None:
-        """0.1a block doesn't support this.
-
-        :return: Always None
+        """If the block version doesn't support this, it should return None.
         """
         return None
 
     @property
     def revealed_next_reps_hash(self) -> None:
-        """0.1a block doesn't support this.
-
-        :return: Always None
+        """If the block version doesn't support this, it should return None.
         """
         return None
 

--- a/loopchain/blockchain/blocks/v0_1a/block.py
+++ b/loopchain/blockchain/blocks/v0_1a/block.py
@@ -1,8 +1,9 @@
 from collections import OrderedDict
-
 from dataclasses import dataclass
+
+from loopchain.blockchain.blocks import BlockHeader as BaseBlockHeader, BlockBody as BaseBlockBody, \
+    _dict__str__
 from loopchain.blockchain.types import Hash32, Address, Signature, ExternalAddress
-from loopchain.blockchain.blocks import BlockHeader as BaseBlockHeader, BlockBody as BaseBlockBody, _dict__str__
 
 
 @dataclass(frozen=True)
@@ -31,6 +32,22 @@ class BlockHeader(BaseBlockHeader):
     def complained(self) -> bool:
         # tx == 0 and peer_id == next_leader >> complained = True
         return self.peer_id == self.next_leader and self.merkle_tree_root_hash == Hash32(bytes(32))
+
+    @property
+    def prep_changed(self) -> None:
+        """0.1a block doesn't support this.
+
+        :return: Always None
+        """
+        return None
+
+    @property
+    def revealed_next_reps_hash(self) -> None:
+        """0.1a block doesn't support this.
+
+        :return: Always None
+        """
+        return None
 
 
 @dataclass(frozen=True)

--- a/loopchain/blockchain/blocks/v0_3/block_verifier.py
+++ b/loopchain/blockchain/blocks/v0_3/block_verifier.py
@@ -114,19 +114,16 @@ class BlockVerifier(BaseBlockVerifier):
                                      f"StateRootHash({header.state_hash}), "
                                      f"Expected({new_block.header.state_hash}).")
             self._handle_exception(exception)
+
         if header.next_reps_hash != new_block.header.next_reps_hash:
-            if not new_block.header.prep_changed \
-                    and header.next_reps_hash == new_block.header.revealed_next_reps_hash:
-                pass
-            else:
-                exception = RuntimeError(f"Block({header.height}, {header.hash.hex()}, "
-                                         f"NextRepsHash({header.next_reps_hash}), "
-                                         f"Expected({new_block.header.next_reps_hash}), "
-                                         f"next_reps_hash({new_block.header.next_reps_hash}), "
-                                         f"revealed_next_reps_hash({new_block.header.revealed_next_reps_hash}), "
-                                         f"origin header({header}), "
-                                         f"new block header({new_block.header}).")
-                self._handle_exception(exception)
+            exception = RuntimeError(f"Block({header.height}, {header.hash.hex()}, "
+                                     f"NextRepsHash({header.next_reps_hash}), "
+                                     f"Expected({new_block.header.next_reps_hash}), "
+                                     f"next_reps_hash({new_block.header.next_reps_hash}), "
+                                     f"revealed_next_reps_hash({new_block.header.revealed_next_reps_hash}), "
+                                     f"origin header({header}), "
+                                     f"new block header({new_block.header}).")
+            self._handle_exception(exception)
 
         builder.state_hash = new_block.header.state_hash
         builder.receipts = invoke_result

--- a/loopchain/blockchain/blocks/v0_3/block_verifier.py
+++ b/loopchain/blockchain/blocks/v0_3/block_verifier.py
@@ -46,8 +46,8 @@ class BlockVerifier(BaseBlockVerifier):
             self.verify_leader_votes(block, prev_block, reps)
 
         if header.height > 1:
-            if prev_block.header.version != "0.1a":
-                prev_next_reps_hash = prev_block.header.next_reps_hash
+            prev_next_reps_hash = prev_block.header.revealed_next_reps_hash
+            if prev_next_reps_hash:
                 if prev_next_reps_hash != header.reps_hash:
                     exception = RuntimeError(f"Block({header.height}, {header.hash.hex()}, "
                                              f"RepsHash({header.reps_hash}), "
@@ -160,11 +160,7 @@ class BlockVerifier(BaseBlockVerifier):
                 self._handle_exception(e)
         else:
             prev_block_header: BlockHeader = prev_block.header
-            if prev_block_header.next_leader != block.header.peer_id:
-                if prev_block_header.reps_hash != prev_block_header.next_reps_hash \
-                        and block.header.peer_id == reps[0]:
-                    # prep term changed!
-                    return
+            if prev_block_header.next_leader != block.header.peer_id and not prev_block_header.prep_changed:
                 exception = RuntimeError(f"Block({block.header.height}, {block.header.hash.hex()}, "
                                          f"Leader({block.header.peer_id.hex_xx()}), "
                                          f"Expected({prev_block_header.next_leader.hex_xx()}).\n "

--- a/loopchain/blockchain/candidate_blocks.py
+++ b/loopchain/blockchain/candidate_blocks.py
@@ -67,10 +67,9 @@ class CandidateBlock:
             logging.debug(f"set block({block.header.hash.hex()}) in CandidateBlock")
             self.__block = block
 
-            if block.header.version != "0.1a" and block.header.reps_hash:
-                reps = ObjectManager().channel_service.block_manager.blockchain.find_preps_addresses_by_roothash(block.header.reps_hash)
-            elif ObjectManager().channel_service:
-                reps = ObjectManager().channel_service.get_rep_ids()
+            channel_service = ObjectManager().channel_service
+            if channel_service:
+                reps = channel_service.block_manager.blockchain.find_preps_addresses_by_header(block.header)
             else:
                 reps = []
 

--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -76,13 +76,9 @@ class Epoch:
         self.new_votes()
 
     def new_votes(self):
-        if self.__blockchain.last_block.header.version != '0.1a':
-            reps_hash = self.__blockchain.last_block.header.next_reps_hash
-        else:
-            reps_hash = ObjectManager().channel_service.peer_manager.prepared_reps_hash
-
+        reps_hash = self.__blockchain.last_block.header.revealed_next_reps_hash or \
+                    ObjectManager().channel_service.peer_manager.prepared_reps_hash
         self.reps = self.__blockchain.find_preps_addresses_by_roothash(reps_hash)
-
         leader_votes = LeaderVotes(self.reps,
                                    conf.LEADER_COMPLAIN_RATIO,
                                    self.height,

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -716,7 +716,8 @@ class ChannelInnerTask:
             f"height({unconfirmed_block.header.height})\n"
             f"hash({unconfirmed_block.header.hash.hex()})")
 
-        if self._channel_service.state_machine.state not in ("Vote", "Watch", "LeaderComplain"):
+        if self._channel_service.state_machine.state not in \
+                ("Vote", "Watch", "LeaderComplain", "BlockGenerate"):
             util.logger.debug(f"Can't add unconfirmed block in state({self._channel_service.state_machine.state}).")
             return
 

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -411,16 +411,13 @@ class ChannelService:
     def get_channel_option(self) -> dict:
         return conf.CHANNEL_OPTION[ChannelProperty().name]
 
-    def get_rep_ids(self) -> list:
-        return [ExternalAddress.fromhex_address(peer_id, allow_malformed=True)
-                for peer_id in self.__peer_manager.peer_list]
-
     def generate_genesis_block(self):
         if self.__block_manager.blockchain.block_height > -1:
             logging.debug("genesis block was already generated")
             return
 
-        reps = self.get_rep_ids()
+        reps = self.block_manager.blockchain.find_preps_addresses_by_roothash(
+            self.peer_manager.prepared_reps_hash)
         self.__block_manager.blockchain.generate_genesis_block(reps)
 
     async def subscribe_to_parent(self):

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -269,11 +269,10 @@ class BlockManager:
 
         last_unconfirmed_block: Block = self.blockchain.last_unconfirmed_block
 
-        reps = self.__channel_service.get_rep_ids()
-
         if unconfirmed_block.header.version == "0.1a" and unconfirmed_block.body.confirm_prev_block:
             need_to_confirm = True
         elif unconfirmed_block.header.version == "0.3":
+            reps = self.blockchain.find_preps_addresses_by_roothash(unconfirmed_block.header.reps_hash)
             leader_votes = LeaderVotes(reps, conf.LEADER_COMPLAIN_RATIO,
                                        unconfirmed_block.header.height, None, unconfirmed_block.body.leader_votes)
             need_to_confirm = leader_votes.get_result() is None

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -147,10 +147,10 @@ class ConsensusSiever(ConsensusBase):
             last_block_header = self._blockchain.last_block.header
             new_term = False
             if last_block_header.version != '0.1a':
-                reps_switched = last_block_header.reps_hash != last_block_header.next_reps_hash
-                block_deprecated = (last_unconfirmed_block is None
-                                    or last_unconfirmed_block.header.peer_id != ChannelProperty().peer_address)
-                if reps_switched and block_deprecated:
+                block_deprecated = (
+                        last_unconfirmed_block is None
+                        or last_unconfirmed_block.header.peer_id != ChannelProperty().peer_address)
+                if last_block_header.prep_changed and block_deprecated:
                     util.logger.info(f"start new term.")
                     new_term = True
                     latest_block = self._blockchain.last_block

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -127,8 +127,8 @@ class ConsensusSiever(ConsensusBase):
         util.logger.debug(f"-------------------consensus-------------------")
         async with self.__lock:
             if self._block_manager.epoch.leader_id != ChannelProperty().peer_id:
-                util.logger.warning(f"This peer is not leader. epoch leader={self._block_manager.epoch.leader_id}")
-                return
+                util.logger.warning(
+                    f"This peer is not leader. epoch leader={self._block_manager.epoch.leader_id}")
 
             self._vote_queue = asyncio.Queue(loop=self._loop)
             complain_votes = self.__get_complaint_votes()
@@ -146,11 +146,9 @@ class ConsensusSiever(ConsensusBase):
             last_unconfirmed_block = self._blockchain.last_unconfirmed_block
             last_block_header = self._blockchain.last_block.header
             new_term = False
-            if last_block_header.version != '0.1a':
-                block_deprecated = (
-                        last_unconfirmed_block is None
-                        or last_unconfirmed_block.header.peer_id != ChannelProperty().peer_address)
-                if last_block_header.prep_changed and block_deprecated:
+            if last_block_header.prep_changed:
+                if last_unconfirmed_block is None or \
+                        last_unconfirmed_block.header.peer_id != ChannelProperty().peer_address:
                     util.logger.info(f"start new term.")
                     new_term = True
                     latest_block = self._blockchain.last_block
@@ -215,14 +213,16 @@ class ConsensusSiever(ConsensusBase):
             except NotEnoughVotes:
                 return
 
-            if self._block_manager.epoch.leader_id != ChannelProperty().peer_id:
+            if self._block_manager.epoch.leader_id != ChannelProperty().peer_id \
+                    and not candidate_block.header.prep_changed:
                 util.logger.spam(
                     f"-------------------turn_to_peer "
                     f"next_leader({self._block_manager.epoch.leader_id}) "
                     f"peer_id({ChannelProperty().peer_id})")
                 ObjectManager().channel_service.reset_leader(self._block_manager.epoch.leader_id)
             else:
-                if self._blockchain.just_before_max_made_block_count:
+                if self._blockchain.just_before_max_made_block_count \
+                        and not candidate_block.header.prep_changed:
                     # (conf.MAX_MADE_BLOCK_COUNT - 1) means if made_block_count is 9,
                     # next unconfirmed block height is 10
                     ObjectManager().channel_service.reset_leader(self._block_manager.epoch.leader_id)

--- a/testcase/unittest/blocks/test_block_pytest.py
+++ b/testcase/unittest/blocks/test_block_pytest.py
@@ -1,0 +1,90 @@
+import os
+
+import pytest
+
+from loopchain.baseservice.score_code import PrepChangedReason
+from loopchain.blockchain.blocks.v0_1a.block import BlockHeader as BlockHeader_v0_1a
+from loopchain.blockchain.blocks.v0_3.block import BlockHeader as BlockHeader_v0_3
+from loopchain.blockchain.types import Address, Signature, Hash32, ExternalAddress, BloomFilter
+
+
+class TestBlockHeader_v0_1a:
+    @pytest.fixture
+    def header_factory(self):
+        def _header(hash_: Hash32 = Hash32.new(),
+                    prev_hash: Hash32 = Hash32.new(),
+                    height: int = 0,
+                    timestamp: int = 0,
+                    peer_id: ExternalAddress = ExternalAddress.new(),
+                    signature: Signature = Signature.new(),
+                    next_leader: Address = Address.new(),
+                    merkle_tree_root_hash: Hash32 = Hash32.new(),
+                    commit_state: dict = dict()) -> BlockHeader_v0_1a:
+
+            return BlockHeader_v0_1a(hash_, prev_hash, height, timestamp, peer_id,
+                                     signature, next_leader, merkle_tree_root_hash, commit_state)
+
+        return _header
+
+    def test_reps_hash_should_be_none(self, header_factory):
+        header: BlockHeader_v0_1a = header_factory()
+
+        assert not header.reps_hash
+
+    def test_prep_changed_should_be_none(self, header_factory):
+        header: BlockHeader_v0_1a = header_factory()
+
+        assert not header.prep_changed
+
+    def test_revealed_next_reps_hash_should_be_none(self, header_factory):
+        header: BlockHeader_v0_1a = header_factory()
+
+        assert not header.revealed_next_reps_hash
+
+
+class TestBlockHeader_v0_3:
+    @pytest.fixture
+    def header_factory(self):
+        def _header(hash_: Hash32 = Hash32.new(),
+                    prev_hash: Hash32 = Hash32.new(),
+                    height: int = 0,
+                    timestamp: int = 0,
+                    peer_id: ExternalAddress = ExternalAddress.new(),
+                    signature: Signature = Signature.new(),
+                    next_leader: ExternalAddress = ExternalAddress.new(),
+                    logs_bloom: BloomFilter = BloomFilter.new(),
+                    transactions_hash: Hash32 = Hash32.new(),
+                    state_hash: Hash32 = Hash32.new(),
+                    receipts_hash: Hash32 = Hash32.new(),
+                    reps_hash: Hash32 = Hash32.new(),
+                    next_reps_hash: Hash32 = Hash32.new(),
+                    leader_votes_hash: Hash32 = Hash32.new(),
+                    prev_votes_hash: Hash32 = Hash32.new()) -> BlockHeader_v0_3:
+
+            return BlockHeader_v0_3(hash_, prev_hash, height, timestamp, peer_id, signature,
+                                    next_leader, logs_bloom, transactions_hash,
+                                    state_hash, receipts_hash, reps_hash,
+                                    next_reps_hash, leader_votes_hash, prev_votes_hash)
+
+        return _header
+
+    def test_prep_is_not_changed_if_next_reps_hash_is_empty(self, header_factory):
+        header = header_factory(next_leader=ExternalAddress(os.urandom(ExternalAddress.size)),
+                                reps_hash=Hash32(os.urandom(Hash32.size)),
+                                next_reps_hash=Hash32.empty())
+
+        assert not header.prep_changed
+
+    def test_prep_changed_by_term_end_if_next_leader_is_empty(self, header_factory):
+        header = header_factory(next_leader=ExternalAddress.empty(),
+                                reps_hash=Hash32(os.urandom(Hash32.size)),
+                                next_reps_hash=Hash32(os.urandom(Hash32.size)))
+
+        assert header.prep_changed == PrepChangedReason.TERM_END
+
+    def test_prep_changed_by_penalty_if_exists_next_reps_hash_and_next_leader(self, header_factory):
+        header = header_factory(next_leader=ExternalAddress(os.urandom(ExternalAddress.size)),
+                                reps_hash=Hash32(os.urandom(Hash32.size)),
+                                next_reps_hash=Hash32(os.urandom(Hash32.size)))
+
+        assert header.prep_changed == PrepChangedReason.PENALTY


### PR DESCRIPTION
# Goal
Set block header attributes according to P-Rep list status.

# Detail
Suppose that 3 cases when build & invoke block.
Each of cases has different block header attributes. Explain below.

## In Case Normal
No changes in P-Rep list

- next_leader: No changes (TODO: ignored when leader-complained?)
- reps_hash: No changes
- next_reps_hash: Set empty hash

## In Case Term End (Reset order)
P-Rep term expired and switched to new list

- next_leader: Set empty hash
- reps_hash: No changes
- next_reps_hash: Invoked value of `next prep root hash` from score

## In case Panelty (Keep Order)
One of P-Rep has been punished and excluded from list 

- next_leader: No changes
- reps_hash: No changes
- next_reps_hash: Invoked value of `next prep root hash` from score