### PR TITLE
[LC-584] Set the `latest_block` to the last block of `blockchain` when the `siever` gets a new term.

### DIFF
--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -150,6 +150,7 @@ class ConsensusSiever(ConsensusBase):
                 if reps_switched and block_deprecated:
                     util.logger.info(f"start new term.")
                     new_term = True
+                    latest_block = self._blockchain.last_block
 
             if last_unconfirmed_block and not last_block_vote_list and not new_term:
                 return


### PR DESCRIPTION
When the new leader of a new term sets the previous block, which is the latest block of the leader node, for validation of a new candidate block. But voters set the previous block, which is the last block of the blockchain, for validation to received block. At this time, it's possible that a difference exists about the value of the block data.
That's why the logic to set `latest_block` is edited when the `siever` gets a new term.