### PR TITLE
[LC-602] Fix a timing issue when the callback function is called after the `LeaderComplain`.

### DIFF
--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -18,7 +18,7 @@ import logging
 import threading
 import traceback
 from concurrent.futures import ThreadPoolExecutor, Future
-from typing import TYPE_CHECKING, Dict, DefaultDict, Optional
+from typing import TYPE_CHECKING, Dict, DefaultDict, Optional, Tuple
 
 from collections import defaultdict
 
@@ -735,7 +735,10 @@ class BlockManager:
         elif self.epoch.height < vote.block_height:
             self.__channel_service.state_machine.block_sync()
 
-    def leader_complain(self):
+    def get_leader_ids_for_complaint(self) -> Tuple[str, str]:
+        """
+        :return: Return complained_leader_id and new_leader_id for the Leader Complaint.
+        """
         complained_leader_id = self.epoch.leader_id
 
         new_leader = self.__channel_service.peer_manager.get_next_leader_peer(
@@ -749,6 +752,10 @@ class BlockManager:
         if not isinstance(complained_leader_id, str):
             complained_leader_id = ""
 
+        return complained_leader_id, new_leader_id
+
+    def leader_complain(self):
+        complained_leader_id, new_leader_id = self.get_leader_ids_for_complaint()
         leader_vote = LeaderVote.new(
             signer=ChannelProperty().peer_auth,
             block_height=self.epoch.height,

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -249,10 +249,10 @@ class ConsensusSiever(ConsensusBase):
                 self.__stop_broadcast_send_unconfirmed_block_timer()
                 return vote
 
-            util.logger.spam(
-                f"not completed vote"
-                f"\nvotes({vote.votes})"
-                f"\nreps({vote.reps})")
+            # util.logger.spam(
+            #     f"not completed vote"
+            #     f"\nvotes({vote.votes})"
+            #     f"\nreps({vote.reps})")
 
             await asyncio.sleep(conf.WAIT_SECONDS_FOR_VOTE)
 


### PR DESCRIPTION
A timing issue occurs when a node is a new leader by the `LeaderComplain` and a callback function of the `LeaderComplain` timeout is called.

- Prevent an unnecessary call the callback function after the `LeaderComplain` timeout when the node is a state of the `BlockGenerate` and the next leader candidate by the `LeaderComplain`. 
- Comment out some logs.