### PR TITLE
[LC-622] add is_rep condition in ConfirmInfoInvalidNeedBlockSync 

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -292,8 +292,9 @@ class BlockChain:
         :return: prev_block (from blockchain or DB) by given block
         """
         prev_hash = block.header.prev_hash
-        if self.last_unconfirmed_block and prev_hash == self.last_unconfirmed_block.header.hash:
-            prev_block = self.last_unconfirmed_block
+        candidate_blocks = self.__block_manager.candidate_blocks
+        if prev_hash in candidate_blocks.blocks.keys():
+            prev_block = candidate_blocks.blocks[prev_hash].block
         else:
             prev_block = self.find_block_by_hash(prev_hash) or self.last_block
         return prev_block

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -474,9 +474,9 @@ class BlockChain:
                     'block_height': self.__block_height
                 }})
 
+            # notify new block
+            ObjectManager().channel_service.inner_service.notify_new_block()
             if ObjectManager().channel_service.state_machine.state != 'BlockSync':
-                # notify new block
-                ObjectManager().channel_service.inner_service.notify_new_block()
                 # reset_network_by_block_height is called in critical section by self.__add_block_lock.
                 # Other Blocks must not be added until reset_network_by_block_height function finishes.
                 ObjectManager().channel_service.switch_role()

--- a/loopchain/blockchain/blocks/v0_3/block_verifier.py
+++ b/loopchain/blockchain/blocks/v0_3/block_verifier.py
@@ -107,28 +107,29 @@ class BlockVerifier(BaseBlockVerifier):
         return invoke_result
 
     def verify_invoke(self, builder: 'BlockBuilder', block: 'Block', prev_block: 'Block'):
-        header: BlockHeader = block.header
         new_block, invoke_result = self.invoke_func(block, prev_block)
-        if header.state_hash != new_block.header.state_hash:
+        header: BlockHeader = block.header
+        new_header: BlockHeader = new_block.header
+        if header.state_hash != new_header.state_hash:
             exception = RuntimeError(f"Block({header.height}, {header.hash.hex()}, "
                                      f"StateRootHash({header.state_hash}), "
-                                     f"Expected({new_block.header.state_hash}).")
+                                     f"Expected({new_header.state_hash}).")
             self._handle_exception(exception)
 
-        if header.next_reps_hash != new_block.header.next_reps_hash:
-            if not new_block.header.prep_changed \
-                    and header.next_reps_hash == new_block.header.revealed_next_reps_hash:
+        if header.next_reps_hash != new_header.next_reps_hash:
+            if (not new_header.prep_changed
+                    and header.next_reps_hash == new_header.revealed_next_reps_hash):
                 pass
             else:
                 exception = RuntimeError(f"Block({header.height}, {header.hash.hex()}, "
                                          f"NextRepsHash({header.next_reps_hash}), "
-                                         f"Expected({new_block.header.next_reps_hash}), "
-                                         f"revealed_next_reps_hash({new_block.header.revealed_next_reps_hash}), "
+                                         f"Expected({new_header.next_reps_hash}), "
+                                         f"revealed_next_reps_hash({new_header.revealed_next_reps_hash}), "
                                          f"\norigin header({header}), "
-                                         f"\nnew block header({new_block.header}).")
+                                         f"\nnew block header({new_header}).")
                 self._handle_exception(exception)
 
-        builder.state_hash = new_block.header.state_hash
+        builder.state_hash = new_header.state_hash
         builder.receipts = invoke_result
 
         builder.build_receipts_hash()

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -815,7 +815,9 @@ class BlockManager:
                 f"trigger block sync: my_height({my_height}), "
                 f"unconfirmed_block.header.height({unconfirmed_block.header.height})")
 
-        if my_height == unconfirmed_block.header.height - 2 and not self.blockchain.last_unconfirmed_block:
+        is_rep = ObjectManager().channel_service.is_support_node_function(conf.NodeFunction.Vote)
+        if (is_rep and my_height == unconfirmed_block.header.height - 2
+                and not self.blockchain.last_unconfirmed_block):
             raise ConfirmInfoInvalidNeedBlockSync(
                 f"trigger block sync: my_height({my_height}), "
                 f"unconfirmed_block.header.height({unconfirmed_block.header.height})")


### PR DESCRIPTION
- get_prev_block from condidate_blocks, not last_unconfirmed_block.
- notify_new_block regardless of state
- add is_rep condition when raise ConfirmInfoInvalidNeedBlockSync, because citizen node always doesn't have last unconfirmed_block and results in getting wrong next_reps_hash.