### PR TITLE
[LC-595] Edit a logic to validate an `unconfirmed_block` and both of `BlockVote` and `LeaderVote` include also validation the `round` and the generator ID.

### DIFF
--- a/loopchain/baseservice/broadcast_command.py
+++ b/loopchain/baseservice/broadcast_command.py
@@ -20,6 +20,7 @@ class BroadcastCommand:
     AUDIENCE_UNSUBSCRIBE = "audience_unsubscribe"
     BROADCAST = "broadcast"
     MAKE_SELF_PEER_CONNECTION = "make_self_connection"
+    SEND_TO_SINGLE_TARGET = "send_to_single_target"
     CONNECT_TO_LEADER = "connect_to_leader"
     CREATE_TX = "create_tx"
     STATUS = "status"

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -370,6 +370,11 @@ class BlockChain:
         preps_ids = self.find_preps_ids_by_roothash(roothash)
         return [ExternalAddress.fromhex(prep_id) for prep_id in preps_ids]
 
+    @lru_cache(maxsize=4, valued_returns_only=True)
+    def find_preps_targets_by_roothash(self, roothash: Hash32) -> dict:
+        preps = self.find_preps_by_roothash(roothash)
+        return {prep["id"]: prep["p2pEndpoint"] for prep in preps}
+
     def find_preps_addresses_by_header(self, header: BlockHeader) -> List[ExternalAddress]:
         try:
             roothash = header.reps_hash

--- a/loopchain/blockchain/blocks/v0_3/block_verifier.py
+++ b/loopchain/blockchain/blocks/v0_3/block_verifier.py
@@ -157,8 +157,9 @@ class BlockVerifier(BaseBlockVerifier):
         body: BlockBody = block.body
         if body.leader_votes:
             any_vote = next(vote for vote in body.leader_votes if vote)
-            leader_votes = LeaderVotes(reps, conf.LEADER_COMPLAIN_RATIO, block.header.height, any_vote.round_,
-                                       any_vote.old_leader, body.leader_votes)
+            leader_votes = LeaderVotes(
+                reps, conf.LEADER_COMPLAIN_RATIO,
+                block.header.height, any_vote.round_, any_vote.old_leader, body.leader_votes)
             if leader_votes.get_result() != block.header.peer_id:
                 exception = RuntimeError(f"Block({block.header.height}, {block.header.hash.hex()}, "
                                          f"Leader({block.header.peer_id.hex_xx()}), "
@@ -181,8 +182,12 @@ class BlockVerifier(BaseBlockVerifier):
     def verify_prev_votes(self, block: 'Block', prev_reps: Sequence[ExternalAddress]):
         header: BlockHeader = block.header
         body: BlockBody = block.body
+        round_ = 0
+        if body.prev_votes:
+            round_ = next(vote for vote in body.prev_votes if vote).round_
 
-        prev_votes = BlockVotes(prev_reps, conf.VOTING_RATIO, header.height - 1, header.prev_hash, body.prev_votes)
+        prev_votes = BlockVotes(
+            prev_reps, conf.VOTING_RATIO, header.height - 1, round_, header.prev_hash, body.prev_votes)
         if prev_votes.get_result() is not True:
             exception = RuntimeError(f"Block({header.height}, {header.hash.hex()}, "
                                      f"PrevVotes {body.prev_votes}")
@@ -192,3 +197,5 @@ class BlockVerifier(BaseBlockVerifier):
         except Exception as e:
             # FIXME : votes.verify does not verify all votes when raising an exception.
             self._handle_exception(e)
+
+

--- a/loopchain/blockchain/blocks/v0_3/block_verifier.py
+++ b/loopchain/blockchain/blocks/v0_3/block_verifier.py
@@ -157,8 +157,8 @@ class BlockVerifier(BaseBlockVerifier):
         body: BlockBody = block.body
         if body.leader_votes:
             any_vote = next(vote for vote in body.leader_votes if vote)
-            leader_votes = LeaderVotes(reps, conf.LEADER_COMPLAIN_RATIO,
-                                       block.header.height, any_vote.old_leader, body.leader_votes)
+            leader_votes = LeaderVotes(reps, conf.LEADER_COMPLAIN_RATIO, block.header.height, any_vote.round_,
+                                       any_vote.old_leader, body.leader_votes)
             if leader_votes.get_result() != block.header.peer_id:
                 exception = RuntimeError(f"Block({block.header.height}, {block.header.hash.hex()}, "
                                          f"Leader({block.header.peer_id.hex_xx()}), "

--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -82,7 +82,6 @@ class Epoch:
                                    self.round,
                                    ExternalAddress.fromhex_address(self.leader_id))
         self.complain_votes[self.round] = leader_votes
-        self.__remove_outdated_complain_votes()
 
     def set_epoch_leader(self, leader_id, complained=False):
         utils.logger.debug(f"Set Epoch leader height({self.height}) leader_id({leader_id})")
@@ -107,19 +106,6 @@ class Epoch:
         except RuntimeError as e:
             logging.warning(e)
 
-    def __remove_outdated_complain_votes(self):
-        utils.logger.spam(f"Try to remove complaint votes on round {self.round}.")
-        round_list = sorted(self.complain_votes.keys())
-        keep_round = self.round - 1
-        if round_list[0] >= keep_round:
-            return
-
-        for round_ in round_list:
-            if round_ < keep_round:
-                del self.complain_votes[round_]
-            elif round_ == keep_round:
-                break
-
     def complain_result(self) -> Optional[str]:
         """return new leader id when complete complain leader.
 
@@ -131,19 +117,6 @@ class Epoch:
             return vote_result.hex_hx()
         else:
             return None
-
-    def _check_unconfirmed_block(self):
-        if self.__blockchain.last_unconfirmed_block:
-            vote = self.__block_manager.candidate_blocks.get_votes(
-                self.__blockchain.last_unconfirmed_block.header.hash)
-            vote_result = vote.get_result(
-                self.__blockchain.last_unconfirmed_block.header.hash.hex(), conf.VOTING_RATIO)
-
-            if not vote_result:
-                utils.logger.debug(
-                    f"last_unconfirmed_block"
-                    f"({self.__blockchain.last_unconfirmed_block.header.hash}), "
-                    f"vote result({vote_result})")
 
     def __add_tx_to_block(self, block_builder):
         tx_queue = self.__block_manager.get_tx_queue()

--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -82,7 +82,7 @@ class Epoch:
                                    self.round,
                                    ExternalAddress.fromhex_address(self.leader_id))
         self.complain_votes[self.round] = leader_votes
-        self.__remove_complain_votes()
+        self.__remove_outdated_complain_votes()
 
     def set_epoch_leader(self, leader_id, complained=False):
         utils.logger.debug(f"Set Epoch leader height({self.height}) leader_id({leader_id})")
@@ -107,7 +107,7 @@ class Epoch:
         except RuntimeError as e:
             logging.warning(e)
 
-    def __remove_complain_votes(self):
+    def __remove_outdated_complain_votes(self):
         utils.logger.spam(f"Try to remove complaint votes on round {self.round}.")
         round_list = sorted(self.complain_votes.keys())
         keep_round = self.round - 1
@@ -116,11 +116,9 @@ class Epoch:
 
         for round_ in round_list:
             if round_ < keep_round:
-                utils.logger.spam(f"Remove complaint votes on {round_} round.")
                 del self.complain_votes[round_]
             elif round_ == keep_round:
                 break
-        utils.logger.spam(f"Complete to remove complaint votes")
 
     def complain_result(self) -> Optional[str]:
         """return new leader id when complete complain leader.

--- a/loopchain/blockchain/votes/v0_1a/vote.py
+++ b/loopchain/blockchain/votes/v0_1a/vote.py
@@ -61,6 +61,7 @@ class BlockVote(BaseVote[bool]):
 @dataclass(frozen=True)
 class LeaderVote(BaseVote[ExternalAddress]):
     block_height: int
+    round_: int
     old_leader: ExternalAddress
     new_leader: ExternalAddress
 
@@ -69,30 +70,32 @@ class LeaderVote(BaseVote[ExternalAddress]):
 
     # noinspection PyMethodOverriding
     @classmethod
-    def new(cls, signer: Signer, timestamp: int,
-            block_height: int, old_leader: ExternalAddress, new_leader: ExternalAddress) -> 'LeaderVote':
-        return super().new(signer, timestamp,
-                           block_height=block_height, old_leader=old_leader, new_leader=new_leader)
+    def new(cls, signer: Signer, timestamp: int, block_height: int, round_: int,
+            old_leader: ExternalAddress, new_leader: ExternalAddress) -> 'LeaderVote':
+        return super().new(signer, timestamp, block_height=block_height, round_=round_,
+                           old_leader=old_leader, new_leader=new_leader)
 
     # noinspection PyMethodOverriding
     @classmethod
-    def empty(cls, rep: ExternalAddress, block_height: int, old_leader: ExternalAddress):
-        return cls(rep, 0, Signature.empty(), block_height, old_leader, ExternalAddress.empty())
+    def empty(cls, rep: ExternalAddress, block_height: int, round_: int, old_leader: ExternalAddress):
+        return cls(rep, 0, Signature.empty(), block_height, round_, old_leader, ExternalAddress.empty())
 
     @classmethod
     def _deserialize(cls, data: dict):
         data_deserialized = super()._deserialize(data)
         data_deserialized["block_height"] = int(data["blockHeight"], 16)
+        data_deserialized["round_"] = data["round_"]
         data_deserialized["old_leader"] = ExternalAddress.fromhex_address(data["oldLeader"])
         data_deserialized["new_leader"] = ExternalAddress.fromhex_address(data["newLeader"])
         return data_deserialized
 
     # noinspection PyMethodOverriding
     @classmethod
-    def to_origin_data(cls, rep: ExternalAddress, timestamp: int,
-                       block_height: int, old_leader: ExternalAddress, new_leader: ExternalAddress):
+    def to_origin_data(cls, rep: ExternalAddress, timestamp: int, block_height: int, round_: int,
+                       old_leader: ExternalAddress, new_leader: ExternalAddress):
         origin_data = super().to_origin_data(rep, timestamp)
         origin_data["blockHeight"] = hex(block_height)
+        origin_data["round_"] = round_
         origin_data["oldLeader"] = old_leader.hex_hx()
         origin_data["newLeader"] = new_leader.hex_hx()
         return origin_data
@@ -100,5 +103,6 @@ class LeaderVote(BaseVote[ExternalAddress]):
     # noinspection PyMethodOverriding
     @classmethod
     def to_hash(cls, rep: ExternalAddress, timestamp: int,
-                block_height: int, old_leader: ExternalAddress, new_leader: ExternalAddress):
-        return super().to_hash(rep, timestamp, block_height=block_height, old_leader=old_leader, new_leader=new_leader)
+                block_height: int, round_: int, old_leader: ExternalAddress, new_leader: ExternalAddress):
+        return super().to_hash(rep, timestamp, block_height=block_height, round_=round_,
+                               old_leader=old_leader, new_leader=new_leader)

--- a/loopchain/blockchain/votes/v0_1a/vote.py
+++ b/loopchain/blockchain/votes/v0_1a/vote.py
@@ -21,6 +21,7 @@ from loopchain.crypto.signature import Signer
 @dataclass(frozen=True)
 class BlockVote(BaseVote[bool]):
     block_height: int
+    round_: int
     block_hash: Hash32
 
     def result(self) -> bool:
@@ -29,8 +30,8 @@ class BlockVote(BaseVote[bool]):
     # noinspection PyMethodOverriding
     @classmethod
     def new(cls, signer: Signer, timestamp: int,
-            block_height: int, block_hash: Union[Hash32, None]) -> 'BlockVote':
-        return super().new(signer, timestamp, block_height=block_height, block_hash=block_hash)
+            block_height: int, round_: int, block_hash: Union[Hash32, None]) -> 'BlockVote':
+        return super().new(signer, timestamp, block_height=block_height, round_=round_, block_hash=block_hash)
 
     # noinspection PyMethodOverriding
     @classmethod
@@ -41,21 +42,23 @@ class BlockVote(BaseVote[bool]):
     def _deserialize(cls, data: dict):
         data_deserialized = super()._deserialize(data)
         data_deserialized["block_height"] = int(data["blockHeight"], 16)
+        data_deserialized["round_"] = data["round_"]
         data_deserialized["block_hash"] = Hash32.fromhex(data["blockHash"])
         return data_deserialized
 
     # noinspection PyMethodOverriding
     @classmethod
-    def to_origin_data(cls, rep: ExternalAddress, timestamp: int, block_height: int, block_hash: Hash32):
+    def to_origin_data(cls, rep: ExternalAddress, timestamp: int, block_height: int, round_: int, block_hash: Hash32):
         origin_data = super().to_origin_data(rep, timestamp)
         origin_data["blockHeight"] = hex(block_height)
+        origin_data["round_"] = round_
         origin_data["blockHash"] = block_hash.hex_0x() if block_hash is not None else None
         return origin_data
 
     # noinspection PyMethodOverriding
     @classmethod
-    def to_hash(cls, rep: ExternalAddress, timestamp: int, block_height: int, block_hash: Hash32):
-        return super().to_hash(rep, timestamp, block_height=block_height, block_hash=block_hash)
+    def to_hash(cls, rep: ExternalAddress, timestamp: int, block_height: int, round_: int, block_hash: Hash32):
+        return super().to_hash(rep, timestamp, block_height=block_height, round_=round_, block_hash=block_hash)
 
 
 @dataclass(frozen=True)

--- a/loopchain/blockchain/votes/v0_1a/votes.py
+++ b/loopchain/blockchain/votes/v0_1a/votes.py
@@ -76,15 +76,20 @@ class BlockVotes(BaseVotes[BlockVote]):
 class LeaderVotes(BaseVotes[LeaderVote]):
     VoteType = LeaderVote
 
-    def __init__(self, reps: Iterable['ExternalAddress'], voting_ratio: float,
-                 block_height: int, old_leader: ExternalAddress, votes: List[LeaderVote] = None):
+    def __init__(self, reps: Iterable['ExternalAddress'], voting_ratio: float, block_height: int, round_: int,
+                 old_leader: ExternalAddress, votes: List[LeaderVote] = None):
         self.block_height = block_height
+        self.round = round_
         self.old_leader = old_leader
         super().__init__(reps, voting_ratio, votes)
 
     def verify_vote(self, vote: LeaderVote):
         if vote.block_height != self.block_height:
             raise RuntimeError(f"Vote block_height not match. {vote.block_height} != {self.block_height}\n"
+                               f"{vote}")
+
+        if vote.round_ != self.round:
+            raise RuntimeError(f"Vote round not match. {vote.round_} != {self.round}\n"
                                f"{vote}")
 
         if vote.old_leader != self.old_leader:
@@ -117,20 +122,23 @@ class LeaderVotes(BaseVotes[LeaderVote]):
     def get_summary(self):
         msg = super().get_summary()
         msg += f"block height({self.block_height})\n"
+        msg += f"round({self.round})\n"
         msg += f"old leader({self.old_leader.hex_hx()})"
         return msg
 
     def __eq__(self, other: 'LeaderVotes'):
         return (
-            super().__eq__(other) and
-            self.block_height == other.block_height and
-            self.old_leader == other.old_leader
+                super().__eq__(other) and
+                self.block_height == other.block_height and
+                self.round == other.round and
+                self.old_leader == other.old_leader
         )
 
     def __repr__(self):
         return (
             f"{self.__class__.__qualname__}(reps={self.reps!r}, voting_ratio={self.voting_ratio!r}, "
-            f"block_height={self.block_height!r}, old_leader={self.old_leader!r}, votes={self.votes!r})"
+            f"block_height={self.block_height!r}, round={self.round!r}, "
+            f"old_leader={self.old_leader!r}, votes={self.votes!r})"
         )
 
     # noinspection PyMethodOverriding

--- a/loopchain/blockchain/votes/votes.py
+++ b/loopchain/blockchain/votes/votes.py
@@ -85,10 +85,10 @@ class Votes(ABC, Generic[TVote]):
     def get_result(self):
         raise NotImplementedError
 
-    def get_majority(self):
+    def get_majority(self, n: int = 1):
         counter = Counter(vote.result() for vote in self.votes if vote)
-        majorities = counter.most_common(1)
-        return majorities[0] if majorities else None
+        majorities = counter.most_common(n)
+        return majorities
 
     def get_summary(self):
         def _fill_space(left_str):

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -703,7 +703,7 @@ class ChannelInnerTask:
                 return response_code, None
 
     @message_queue_task(type_=MessageQueueType.Worker)
-    async def announce_unconfirmed_block(self, block_dumped) -> None:
+    async def announce_unconfirmed_block(self, block_dumped, round_: int) -> None:
         try:
             unconfirmed_block = self._blockchain.block_loads(block_dumped)
         except BlockError as e:
@@ -728,7 +728,7 @@ class ChannelInnerTask:
             return
 
         try:
-            self._block_manager.verify_confirm_info(unconfirmed_block)
+            self._block_manager.verify_confirm_info(unconfirmed_block, round_)
         except ConfirmInfoInvalid as e:
             util.logger.warning(f"ConfirmInfoInvalid {e}")
         except ConfirmInfoInvalidNeedBlockSync as e:
@@ -743,7 +743,7 @@ class ChannelInnerTask:
         except NotReadyToConfirmInfo as e:
             util.logger.warning(f"NotReadyToConfirmInfo {e}")
         else:
-            self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block)
+            self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block, round_=round_)
 
     @message_queue_task(type_=MessageQueueType.Worker)
     async def announce_unrecorded_block(self, block_dumped) -> None:

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -715,6 +715,7 @@ class ChannelInnerTask:
             f"announce_unconfirmed_block \n"
             f"peer_id({unconfirmed_block.header.peer_id.hex()})\n"
             f"height({unconfirmed_block.header.height})\n"
+            f"round({round_})\n"
             f"hash({unconfirmed_block.header.hash.hex()})")
 
         if self._channel_service.state_machine.state not in \
@@ -746,7 +747,7 @@ class ChannelInnerTask:
             self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block, round_=round_)
 
     @message_queue_task(type_=MessageQueueType.Worker)
-    async def announce_unrecorded_block(self, block_dumped) -> None:
+    async def announce_unrecorded_block(self, block_dumped, round_: int) -> None:
         try:
             unrecorded_block = self._blockchain.block_loads(block_dumped)
         except BlockError as e:
@@ -758,6 +759,7 @@ class ChannelInnerTask:
             f"announce_unrecorded_block \n"
             f"peer_id({unrecorded_block.header.peer_id.hex()})\n"
             f"height({unrecorded_block.header.height})\n"
+            f"round({round_})\n"
             f"hash({unrecorded_block.header.hash.hex()})")
 
         if self._channel_service.state_machine.state not in \
@@ -771,7 +773,7 @@ class ChannelInnerTask:
             return
 
         try:
-            self._block_manager.verify_confirm_info(unrecorded_block)
+            self._block_manager.verify_confirm_info(unrecorded_block, round_)
         except ConfirmInfoInvalid as e:
             util.logger.warning(f"ConfirmInfoInvalid {e}")
         except ConfirmInfoInvalidNeedBlockSync as e:
@@ -786,7 +788,10 @@ class ChannelInnerTask:
         except NotReadyToConfirmInfo as e:
             util.logger.warning(f"NotReadyToConfirmInfo {e}")
         else:
-            self._channel_service.state_machine.vote(unconfirmed_block=unrecorded_block, is_unrecorded_block=True)
+            self._channel_service.state_machine.vote(
+                unconfirmed_block=unrecorded_block,
+                round_=round_,
+                is_unrecorded_block=True)
 
     @message_queue_task
     def block_sync(self, block_hash, block_height):
@@ -837,7 +842,8 @@ class ChannelInnerTask:
             raise
         else:
             vote = BlockVote.deserialize(vote_serialized)
-            util.logger.debug(f"Peer vote to : {vote.block_height} {vote.block_hash} from {vote.rep.hex_hx()}")
+            util.logger.debug(
+                f"Peer vote to : {vote.block_height}({vote.round_}) {vote.block_hash} from {vote.rep.hex_hx()}")
             self._block_manager.candidate_blocks.add_vote(vote)
 
             if self._channel_service.state_machine.state == "BlockGenerate" and \

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -848,7 +848,6 @@ class ChannelInnerTask:
     async def complain_leader(self, vote_dumped: str) -> None:
         vote_serialized = json.loads(vote_dumped)
         vote = LeaderVote.deserialize(vote_serialized)
-
         self._block_manager.add_complain(vote)
 
     @message_queue_task

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -33,9 +33,9 @@ from loopchain.blockchain.transactions import (Transaction, TransactionSerialize
 from loopchain.blockchain.types import Hash32
 from loopchain.blockchain.votes.v0_1a import BlockVote, LeaderVote
 from loopchain.channel.channel_property import ChannelProperty
+from loopchain.jsonrpc.exception import JsonError
 from loopchain.protos import loopchain_pb2, message_code
 from loopchain.qos.qos_controller import QosController, QosCountControl
-from loopchain.jsonrpc.exception import JsonError
 from loopchain.utils.message_queue import StubCollection
 
 if TYPE_CHECKING:
@@ -729,7 +729,7 @@ class ChannelInnerTask:
             return
 
         try:
-            self._block_manager.verify_confirm_info(unconfirmed_block, round_)
+            self._block_manager.verify_confirm_info(unconfirmed_block)
         except ConfirmInfoInvalid as e:
             util.logger.warning(f"ConfirmInfoInvalid {e}")
         except ConfirmInfoInvalidNeedBlockSync as e:
@@ -773,7 +773,7 @@ class ChannelInnerTask:
             return
 
         try:
-            self._block_manager.verify_confirm_info(unrecorded_block, round_)
+            self._block_manager.verify_confirm_info(unrecorded_block)
         except ConfirmInfoInvalid as e:
             util.logger.warning(f"ConfirmInfoInvalid {e}")
         except ConfirmInfoInvalidNeedBlockSync as e:

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -455,7 +455,7 @@ class ChannelService:
 
     async def set_peer_type_in_channel(self):
         peer_type = loopchain_pb2.PEER
-        leader_id = self.__block_manager.get_next_leader(self.__block_manager.blockchain.last_block)
+        leader_id = self.__block_manager.get_next_leader_by_block(self.__block_manager.blockchain.last_block)
         utils.logger.info(f"channel({ChannelProperty().name}) peer_leader: {leader_id}")
 
         logger_preset = loggers.get_preset()

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -145,7 +145,7 @@ class ChannelStateMachine(object):
     def _do_evaluate_network(self):
         self._run_coroutine_threadsafe(self.__channel_service.evaluate_network())
 
-    def _do_vote(self, unconfirmed_block: Block, is_unrecorded_block: bool = False):
+    def _do_vote(self, unconfirmed_block: Block, round_: int, is_unrecorded_block: bool = False):
         if is_unrecorded_block:
             try:
                 self._run_coroutine_threadsafe(
@@ -153,7 +153,7 @@ class ChannelStateMachine(object):
             except UnrecordedBlock as e:
                 util.logger.info(e)
         else:
-            self._run_coroutine_threadsafe(self.__channel_service.block_manager.vote_as_peer(unconfirmed_block))
+            self._run_coroutine_threadsafe(self.__channel_service.block_manager.vote_as_peer(unconfirmed_block, round_))
 
     def _consensus_on_enter(self, *args, **kwargs):
         self.block_height_sync()

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -21,7 +21,7 @@ from transitions import State
 
 import loopchain.utils as util
 from loopchain import configure as conf
-from loopchain.blockchain import UnrecordedBlock
+from loopchain.blockchain import UnrecordedBlock, InvalidUnconfirmedBlock
 from loopchain.blockchain.blocks import Block
 from loopchain.peer import status_code, ChannelProperty
 from loopchain.protos import loopchain_pb2
@@ -149,9 +149,13 @@ class ChannelStateMachine(object):
         if is_unrecorded_block:
             try:
                 self._run_coroutine_threadsafe(
-                    self.__channel_service.block_manager.add_unconfirmed_block(unconfirmed_block, is_unrecorded_block))
+                    self.__channel_service.block_manager.add_unconfirmed_block(
+                        unconfirmed_block, round_, is_unrecorded_block)
+                )
             except UnrecordedBlock as e:
                 util.logger.info(e)
+            except InvalidUnconfirmedBlock as e:
+                util.logger.spam(f"The Unrecorded block is unnecessary to vote.")
         else:
             self._run_coroutine_threadsafe(self.__channel_service.block_manager.vote_as_peer(unconfirmed_block, round_))
 

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -784,16 +784,14 @@ class BlockManager:
         reps_hash = self.blockchain.last_block.header.revealed_next_reps_hash or \
                     self.__channel_service.peer_manager.prepared_reps_hash
         rep_id = leader_vote.rep.hex_hx()
-        for rep in self.blockchain.find_preps_by_roothash(reps_hash):
-            if rep["id"] == rep_id:
-                target = rep["p2pEndpoint"]
-                break
+        target = self.blockchain.find_preps_targets_by_roothash(reps_hash)[rep_id]
 
         util.logger.debug(
             f"fail leader complain "
             f"complained_leader_id({leader_vote.old_leader}), "
             f"new_leader_id({ExternalAddress.empty()}),"
-            f"round({leader_vote.round_})")
+            f"round({leader_vote.round_}),"
+            f"target({target})")
 
         self.__channel_service.broadcast_scheduler.schedule_send_failed_leader_complain(
             "ComplainLeader", request, target=target

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -187,17 +187,17 @@ class BlockManager:
             reps_hash=target_reps_hash
         )
 
-    def _send_unrecorded_block(self, block_: Block, target_reps_hash):
+    def _send_unrecorded_block(self, block_: Block, target_reps_hash, round_: int):
         util.logger.debug(
             f"BroadCast AnnounceUnrecordedBlock "
-            f"height({block_.header.height}) block({block_.header.hash}) peers: "
+            f"height({block_.header.height}) round({round_}) block({block_.header.hash}) peers: "
             f"{ObjectManager().channel_service.peer_manager.get_peer_count()} "
             f"target_reps_hash({target_reps_hash})")
 
         block_dumped = self.blockchain.block_dumps(block_)
         ObjectManager().channel_service.broadcast_scheduler.schedule_broadcast(
             "AnnounceUnrecordedBlock",
-            loopchain_pb2.BlockSend(block=block_dumped, channel=self.__channel_name),
+            loopchain_pb2.BlockSend(block=block_dumped, round_=round_, channel=self.__channel_name),
             reps_hash=target_reps_hash
         )
 
@@ -280,14 +280,9 @@ class BlockManager:
         current_state = self.__channel_service.state_machine.state
         block_header = unconfirmed_block.header
 
-        if self.epoch.height == block_header.height and self.epoch.round > round_:
+        if self.epoch.height == block_header.height and self.epoch.round < round_:
             raise InvalidUnconfirmedBlock(
                 f"The unconfirmed block has invalid round. Expected({self.epoch.round}), Unconfirmed_block({round_})")
-
-        if self.epoch.round != round_:
-            raise InvalidUnconfirmedBlock(
-                f"The unconfirmed block is made by an unexpected round. "
-                f"Expected({self.epoch.round}), Unconfirmed_block({round_})")
 
         if not self.epoch.complained_result and self.epoch.leader_id != block_header.peer_id.hex_hx():
             raise InvalidUnconfirmedBlock(
@@ -304,8 +299,8 @@ class BlockManager:
         :param is_unrecorded_block:
         :return:
         """
-        self.__validate_duplication_of_unconfirmed_block(unconfirmed_block)
         self.__validate_epoch_of_unconfirmed_block(unconfirmed_block, round_)
+        self.__validate_duplication_of_unconfirmed_block(unconfirmed_block)
 
         last_unconfirmed_block: Block = self.blockchain.last_unconfirmed_block
         if unconfirmed_block.header.reps_hash:
@@ -813,12 +808,13 @@ class BlockManager:
         self.__channel_service.broadcast_scheduler.schedule_broadcast(
             "ComplainLeader", request, reps_hash=self.__channel_service.peer_manager.prepared_reps_hash)
 
-    def vote_unconfirmed_block(self, block: Block, is_validated):
+    def vote_unconfirmed_block(self, block: Block, round_: int, is_validated):
         logging.debug(f"block_manager:vote_unconfirmed_block ({self.channel_name}/{is_validated})")
 
         vote = BlockVote.new(
             signer=ChannelProperty().peer_auth,
             block_height=block.header.height,
+            round_=round_,
             block_hash=block.header.hash if is_validated else Hash32.empty(),
             timestamp=util.get_time_stamp()
         )
@@ -877,7 +873,7 @@ class BlockManager:
             traceback.print_exc()
             raise ConfirmInfoInvalid("Unconfirmed block has no valid confirm info for previous block")
 
-    async def _vote(self, unconfirmed_block: Block):
+    async def _vote(self, unconfirmed_block: Block, round_: int):
         exc = None
         try:
             block_version = self.blockchain.block_versioner.get_version(unconfirmed_block.header.height)
@@ -906,7 +902,7 @@ class BlockManager:
             self._reset_leader(unconfirmed_block)
         finally:
             is_validated = exc is None
-            vote = self.vote_unconfirmed_block(unconfirmed_block, is_validated)
+            vote = self.vote_unconfirmed_block(unconfirmed_block, round_, is_validated)
             if self.__channel_service.state_machine.state == "BlockGenerate" and self.consensus_algorithm:
                 self.consensus_algorithm.vote(vote)
 
@@ -928,6 +924,6 @@ class BlockManager:
             util.logger.info(e)
         except DuplicationUnconfirmedBlock as e:
             util.logger.debug(e)
-            await self._vote(unconfirmed_block)
+            await self._vote(unconfirmed_block, round_)
         else:
-            await self._vote(unconfirmed_block)
+            await self._vote(unconfirmed_block, round_)

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -171,7 +171,6 @@ class ConsensusSiever(ConsensusBase):
                 complain_votes, last_block_vote_list, skip_add_tx, next_reps, next_leader)
             need_next_call = False
             round_ = self._block_manager.epoch.round
-            util.logger.warning(f"before broadcast : {round_}")
             try:
                 if complained_result or new_term:
                     util.logger.spam("consensus block_builder.complained or new term")
@@ -218,7 +217,6 @@ class ConsensusSiever(ConsensusBase):
             util.logger.spam(f"candidate block : {candidate_block.header}")
             self._block_manager.candidate_blocks.add_block(candidate_block)
             self.__broadcast_block(candidate_block, max(self._block_manager.epoch.round, round_), is_unrecorded_block)
-            util.logger.warning(f"after broadcast : {self._block_manager.epoch.round}/{round_}")
             self._block_manager.vote_unconfirmed_block(candidate_block, True)
 
             if is_unrecorded_block:

--- a/loopchain/peer/peer_outer_service.py
+++ b/loopchain/peer/peer_outer_service.py
@@ -496,7 +496,7 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
         channel_name = conf.LOOPCHAIN_DEFAULT_CHANNEL if request.channel == '' else request.channel
         channel_stub = StubCollection().channel_stubs[channel_name]
         asyncio.run_coroutine_threadsafe(
-            channel_stub.async_task().announce_unconfirmed_block(request.block),
+            channel_stub.async_task().announce_unconfirmed_block(request.block, request.round_),
             self.peer_service.inner_service.loop
         )
         return loopchain_pb2.CommonReply(response_code=message_code.Response.success, message="success")

--- a/loopchain/peer/peer_outer_service.py
+++ b/loopchain/peer/peer_outer_service.py
@@ -350,9 +350,7 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
 
         channel_stub = StubCollection().channel_stubs[channel]
         asyncio.run_coroutine_threadsafe(
-            channel_stub.async_task().complain_leader(
-                vote_dumped=request.complain_vote
-            ),
+            channel_stub.async_task().complain_leader(vote_dumped=request.complain_vote),
             self.peer_service.inner_service.loop
         )
 
@@ -511,7 +509,7 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
         channel_name = conf.LOOPCHAIN_DEFAULT_CHANNEL if request.channel == '' else request.channel
         channel_stub = StubCollection().channel_stubs[channel_name]
         asyncio.run_coroutine_threadsafe(
-            channel_stub.async_task().announce_unrecorded_block(request.block),
+            channel_stub.async_task().announce_unrecorded_block(request.block, request.round_),
             self.peer_service.inner_service.loop
         )
         return loopchain_pb2.CommonReply(response_code=message_code.Response.success, message="success")

--- a/loopchain/protos/loopchain.proto
+++ b/loopchain/protos/loopchain.proto
@@ -55,7 +55,6 @@ service PeerService {
     // Subscribe 후 broadcast 받는 인터페이스는 Announce- 로 시작한다.
     rpc AnnounceUnconfirmedBlock (BlockSend) returns (CommonReply) {}
     rpc AnnounceUnrecordedBlock (BlockSend) returns (CommonReply) {}
-    rpc AnnounceNewBlockForVote (NewBlockSend) returns (CommonReply) {}
     rpc AnnounceConfirmedBlock (BlockAnnounce) returns (CommonReply) {}
     // Test 검증을 위한 인터페이스
     rpc Echo (CommonRequest) returns (CommonReply) {}
@@ -254,12 +253,7 @@ message PrecommitBlockReply {
 //[Peer&BlockGenerator] for send Block, this message type shared in AnnounceUnconfirmedBlock and SendConfirmedBlock
 message BlockSend {
     required bytes block = 1;
-    optional string channel = 2; // channel ID for multichain network
-}
-
-message NewBlockSend {
-    required bytes block = 1;
-    required bytes epoch = 2;
+    required int32 round_ = 2;
     optional string channel = 3; // channel ID for multichain network
 }
 

--- a/testcase/unittest/test_block.py
+++ b/testcase/unittest/test_block.py
@@ -254,8 +254,8 @@ class TestBlock(unittest.TestCase):
         block_builder.reps = [ExternalAddress.fromhex_address(test_signer.address)]
         block_builder.next_leader = ExternalAddress.fromhex("hx00112233445566778899aabbccddeeff00112233")
 
-        vote = BlockVote.new(test_signer, utils.get_time_stamp(), block_builder.height - 1, block_builder.prev_hash)
-        votes = BlockVotes(block_builder.reps, conf.VOTING_RATIO, block_builder.height - 1, block_builder.prev_hash)
+        vote = BlockVote.new(test_signer, utils.get_time_stamp(), block_builder.height - 1, 0, block_builder.prev_hash)
+        votes = BlockVotes(block_builder.reps, conf.VOTING_RATIO, block_builder.height - 1, 0, block_builder.prev_hash)
         votes.add_vote(vote)
         block_builder.prev_votes = votes.votes
 

--- a/testcase/unittest/test_vote.py
+++ b/testcase/unittest/test_vote.py
@@ -43,11 +43,11 @@ class TestVote(unittest.TestCase):
     def test_block_vote(self):
         signer = self.signers[0]
         block_hash = Hash32(os.urandom(Hash32.size))
-        block_vote = BlockVote.new(signer, 0, 0, block_hash)
+        block_vote = BlockVote.new(signer, 0, 0, 0, block_hash)
         block_vote.verify()
 
         origin = f"icx_vote.blockHash.{block_vote.block_hash.hex_0x()}.blockHeight.{hex(block_vote.block_height)}."
-        origin += f"rep.{block_vote.rep.hex_hx()}.timestamp.{hex(block_vote.timestamp)}"
+        origin += f"rep.{block_vote.rep.hex_hx()}.round_.{block_vote.round_}.timestamp.{hex(block_vote.timestamp)}"
 
         origin_data = block_vote.to_origin_data(**block_vote.origin_args())
         self.assertEqual(origin, vote.hash_generator.generate_salted_origin(origin_data))
@@ -58,13 +58,13 @@ class TestVote(unittest.TestCase):
     def test_block_votes_true(self):
         ratio = 0.67
         block_hash = Hash32(os.urandom(Hash32.size))
-        block_votes = BlockVotes(self.reps, ratio, 0, block_hash)
+        block_votes = BlockVotes(self.reps, ratio, 0, 0, block_hash)
 
         for i, signer in enumerate(self.signers):
             if i == 66:
                 break
 
-            block_vote = BlockVote.new(signer, 0, 0, block_hash)
+            block_vote = BlockVote.new(signer, 0, 0, 0, block_hash)
             block_votes.add_vote(block_vote)
 
         self.assertEqual(block_votes.quorum, len(self.reps) * ratio)
@@ -73,7 +73,7 @@ class TestVote(unittest.TestCase):
         self.assertEqual(block_votes.is_completed(), False)
         self.assertEqual(block_votes.get_result(), None)
 
-        block_vote = BlockVote.new(self.signers[99], 0, 0, block_hash)
+        block_vote = BlockVote.new(self.signers[99], 0, 0, 0, block_hash)
         block_votes.add_vote(block_vote)
 
         self.assertEqual(block_votes.is_completed(), True)
@@ -82,13 +82,13 @@ class TestVote(unittest.TestCase):
     def test_block_votes_false(self):
         ratio = 0.67
         block_hash = Hash32(os.urandom(Hash32.size))
-        block_votes = BlockVotes(self.reps, ratio, 0, block_hash)
+        block_votes = BlockVotes(self.reps, ratio, 0, 0, block_hash)
 
         for i, signer in enumerate(self.signers):
             if i % 4 == 0:
-                block_vote = BlockVote.new(signer, 0, 0, block_hash)
+                block_vote = BlockVote.new(signer, 0, 0, 0, block_hash)
             else:
-                block_vote = BlockVote.new(signer, 0, 0, Hash32.empty())
+                block_vote = BlockVote.new(signer, 0, 0, 0, Hash32.empty())
             block_votes.add_vote(block_vote)
 
         logging.info(block_votes)
@@ -98,13 +98,13 @@ class TestVote(unittest.TestCase):
     def test_block_votes_fail(self):
         ratio = 0.67
         block_hash = Hash32(os.urandom(Hash32.size))
-        block_votes = BlockVotes(self.reps, ratio, 0, block_hash)
+        block_votes = BlockVotes(self.reps, ratio, 0, 0, block_hash)
 
         for i, signer in enumerate(self.signers):
             if i == 33:
                 break
 
-            block_vote = BlockVote.new(signer, 0, 0, Hash32.empty())
+            block_vote = BlockVote.new(signer, 0, 0, 0, Hash32.empty())
             block_votes.add_vote(block_vote)
 
         self.assertEqual(block_votes.quorum, len(self.reps) * ratio)
@@ -113,7 +113,7 @@ class TestVote(unittest.TestCase):
         self.assertEqual(block_votes.is_completed(), False)
         self.assertEqual(block_votes.get_result(), None)
 
-        block_vote = BlockVote.new(self.signers[99], 0, 0, Hash32.empty())
+        block_vote = BlockVote.new(self.signers[99], 0, 0, 0, Hash32.empty())
         block_votes.add_vote(block_vote)
 
         logging.info(block_votes)
@@ -123,11 +123,11 @@ class TestVote(unittest.TestCase):
     def test_block_votes_completed(self):
         ratio = 0.67
         block_hash = Hash32(os.urandom(Hash32.size))
-        block_votes = BlockVotes(self.reps, ratio, 0, block_hash)
+        block_votes = BlockVotes(self.reps, ratio, 0, 0, block_hash)
 
         signers = list(enumerate(self.signers))
         for i, signer in signers[:25]:
-            block_vote = BlockVote.new(signer, 0, 0, block_hash)
+            block_vote = BlockVote.new(signer, 0, 0, 0, block_hash)
             block_votes.add_vote(block_vote)
 
         logging.info(block_votes)
@@ -135,7 +135,7 @@ class TestVote(unittest.TestCase):
         self.assertEqual(block_votes.get_result(), None)
 
         for i, signer in signers[25:50]:
-            block_vote = BlockVote.new(signer, 0, 0, block_hash)
+            block_vote = BlockVote.new(signer, 0, 0, 0, block_hash)
             block_votes.add_vote(block_vote)
 
         logging.info(block_votes)
@@ -143,7 +143,7 @@ class TestVote(unittest.TestCase):
         self.assertEqual(block_votes.get_result(), None)
 
         for i, signer in signers[50:75]:
-            block_vote = BlockVote.new(signer, 0, 0, Hash32.empty())
+            block_vote = BlockVote.new(signer, 0, 0, 0, Hash32.empty())
             block_votes.add_vote(block_vote)
 
         logging.info(block_votes)
@@ -151,7 +151,7 @@ class TestVote(unittest.TestCase):
         self.assertEqual(block_votes.get_result(), None)
 
         for i, signer in signers[75:90]:
-            block_vote = BlockVote.new(signer, 0, 0, Hash32.empty())
+            block_vote = BlockVote.new(signer, 0, 0, 0, Hash32.empty())
             block_votes.add_vote(block_vote)
 
         logging.info(block_votes)
@@ -161,21 +161,24 @@ class TestVote(unittest.TestCase):
     def test_block_invalid_vote(self):
         ratio = 0.67
         block_hash = Hash32(os.urandom(Hash32.size))
-        block_votes = BlockVotes(self.reps, ratio, 0, block_hash)
+        block_votes = BlockVotes(self.reps, ratio, 0, 0, block_hash)
 
-        invalid_block_vote = BlockVote.new(self.signers[0], 0, 1, block_hash)
+        invalid_block_vote = BlockVote.new(self.signers[0], 0, 0, 1, block_hash)
         self.assertRaises(RuntimeError, block_votes.add_vote, invalid_block_vote)
 
-        invalid_block_vote = BlockVote.new(self.signers[0], 0, 0, Hash32(os.urandom(32)))
+        invalid_block_vote = BlockVote.new(self.signers[0], 0, 1, 0, block_hash)
+        self.assertRaises(RuntimeError, block_votes.add_vote, invalid_block_vote)
+
+        invalid_block_vote = BlockVote.new(self.signers[0], 0, 0, 0, Hash32(os.urandom(32)))
         self.assertRaises(RuntimeError, block_votes.add_vote, invalid_block_vote)
 
         invalid_block_vote = BlockVote(rep=self.reps[0], timestamp=0, signature=Signature(os.urandom(65)),
-                                       block_height=0, block_hash=block_hash)
+                                       block_height=0, round_=0, block_hash=block_hash)
         self.assertRaises(RuntimeError, block_votes.add_vote, invalid_block_vote)
 
-        block_vote = BlockVote.new(self.signers[0], 0, 0, block_hash)
+        block_vote = BlockVote.new(self.signers[0], 0, 0, 0, block_hash)
         block_votes.add_vote(block_vote)
-        duplicate_block_vote = BlockVote.new(self.signers[0], 0, 0, Hash32.empty())
+        duplicate_block_vote = BlockVote.new(self.signers[0], 0, 0, 0, Hash32.empty())
         self.assertRaises(votes.VoteDuplicateError, block_votes.add_vote, duplicate_block_vote)
 
     def test_leader_vote(self):


### PR DESCRIPTION
- Edit a logic to validate an `unconfirmed_block` and both of `BlockVote` and `LeaderVote` include also validation the `round` and the generator ID.
- Add `round` to the `BlockSend` and `LeaderVote` message.
- Add `__remove_outdated_complain_votes()` and apply after call `new_round()`.
- Edit a variable name to be short.
- Edit the related testcase.
- Remove some unnecessary logs and a message.