### PR TITLE
[LC-642] fix  'NoneType' object has no attribute 'peer_id' in set_leader_peer

### DIFF
--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -536,6 +536,7 @@ class ChannelService:
     def set_new_leader(self):
         new_leader_id = self.block_manager.get_next_leader(self.block_manager.blockchain.latest_block)
         if new_leader_id:
+            self.__peer_manager.update_all_peers()
             new_leader = self.peer_manager.get_peer(new_leader_id)
             self.peer_manager.set_leader_peer(new_leader)
 

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -265,10 +265,11 @@ class BlockManager:
         raise DuplicationUnconfirmedBlock("Unconfirmed block has already been added.")
 
     def __check_unrecorded_block(self, unconfirmed_block: Block):
-        expected_generator = self.blockchain.get_first_leader_of_next_reps(self.blockchain.last_block)
-        if self.blockchain.last_block.header.prep_changed and \
-                unconfirmed_block.header.peer_id != ExternalAddress.fromhex(expected_generator):
-            raise UnrecordedBlock
+        if self.blockchain.last_block.header.revealed_next_reps_hash:
+            expected_generator = self.blockchain.get_first_leader_of_next_reps(self.blockchain.last_block)
+            if self.blockchain.last_block.header.prep_changed and \
+                    unconfirmed_block.header.peer_id != ExternalAddress.fromhex(expected_generator):
+                raise UnrecordedBlock
 
     def add_unconfirmed_block(self, unconfirmed_block: Block):
         """


### PR DESCRIPTION
fix  'NoneType' object has no attribute 'peer_id' in set_leader_peer.