### PR TITLE
[LC-656] Edit logic to be ignored the `unrecorded block` always.

### DIFF
--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -189,7 +189,8 @@ class Epoch:
                     continue
             utils.logger.spam(f"There is no duplicated tx anymore.")
 
-    def makeup_block(self, complain_votes: LeaderVotes, prev_votes, skip_add_tx=False):
+    def makeup_block(self, complain_votes: LeaderVotes, prev_votes,
+                     skip_add_tx=False, next_reps=None, next_leader=None):
         last_block = self.__blockchain.last_unconfirmed_block or self.__blockchain.last_block
         block_height = last_block.header.height + 1
         block_version = self.__blockchain.block_versioner.get_version(block_height)
@@ -197,7 +198,11 @@ class Epoch:
         block_builder.prev_votes = prev_votes
         if complain_votes and complain_votes.get_result():
             block_builder.leader_votes = complain_votes.votes
-        elif not skip_add_tx:
+
+        if skip_add_tx:
+            block_builder.next_leader = next_leader
+            block_builder.reps = next_reps
+        else:
             self.__add_tx_to_block(block_builder)
 
         return block_builder

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -745,6 +745,49 @@ class ChannelInnerTask:
         else:
             self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block)
 
+    @message_queue_task(type_=MessageQueueType.Worker)
+    async def announce_unrecorded_block(self, block_dumped) -> None:
+        try:
+            unrecorded_block = self._blockchain.block_loads(block_dumped)
+        except BlockError as e:
+            traceback.print_exc()
+            logging.error(f"announce_unrecorded_block: {e}")
+            return
+
+        util.logger.debug(
+            f"announce_unrecorded_block \n"
+            f"peer_id({unrecorded_block.header.peer_id.hex()})\n"
+            f"height({unrecorded_block.header.height})\n"
+            f"hash({unrecorded_block.header.hash.hex()})")
+
+        if self._channel_service.state_machine.state not in \
+                ("Vote", "Watch", "LeaderComplain", "BlockGenerate"):
+            util.logger.debug(f"Can't add unrecorded block in state({self._channel_service.state_machine.state}).")
+            return
+
+        last_block = self._blockchain.last_block
+        if last_block is None:
+            util.logger.debug("BlockChain has not been initialized yet.")
+            return
+
+        try:
+            self._block_manager.verify_confirm_info(unrecorded_block)
+        except ConfirmInfoInvalid as e:
+            util.logger.warning(f"ConfirmInfoInvalid {e}")
+        except ConfirmInfoInvalidNeedBlockSync as e:
+            util.logger.debug(f"ConfirmInfoInvalidNeedBlockSync {e}")
+            if self._channel_service.state_machine.state == "BlockGenerate" and (
+                    self._block_manager.consensus_algorithm and self._block_manager.consensus_algorithm.is_running):
+                self._block_manager.consensus_algorithm.stop()
+            else:
+                self._channel_service.state_machine.block_sync()
+        except ConfirmInfoInvalidAddedBlock as e:
+            util.logger.warning(f"ConfirmInfoInvalidAddedBlock {e}")
+        except NotReadyToConfirmInfo as e:
+            util.logger.warning(f"NotReadyToConfirmInfo {e}")
+        else:
+            self._channel_service.state_machine.vote(unconfirmed_block=unrecorded_block, is_unrecorded_block=True)
+
     @message_queue_task
     def block_sync(self, block_hash, block_height):
         response_message = None

--- a/loopchain/peer/peer_outer_service.py
+++ b/loopchain/peer/peer_outer_service.py
@@ -487,7 +487,7 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
         return loopchain_pb2.GetInvokeResultReply(response_code=response_code, result=result)
 
     def AnnounceUnconfirmedBlock(self, request, context):
-        """수집된 tx 로 생성한 Block 을 각 peer 에 전송하여 검증을 요청한다.
+        """Send the UnconfirmedBlock includes collected transactions to reps and request to verify it.
 
         :param request:
         :param context:
@@ -497,6 +497,21 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
         channel_stub = StubCollection().channel_stubs[channel_name]
         asyncio.run_coroutine_threadsafe(
             channel_stub.async_task().announce_unconfirmed_block(request.block),
+            self.peer_service.inner_service.loop
+        )
+        return loopchain_pb2.CommonReply(response_code=message_code.Response.success, message="success")
+
+    def AnnounceUnrecordedBlock(self, request, context):
+        """Send the UnrecordedBlock to reps and request to verify it.
+
+        :param request:
+        :param context:
+        :return:
+        """
+        channel_name = conf.LOOPCHAIN_DEFAULT_CHANNEL if request.channel == '' else request.channel
+        channel_stub = StubCollection().channel_stubs[channel_name]
+        asyncio.run_coroutine_threadsafe(
+            channel_stub.async_task().announce_unrecorded_block(request.block),
             self.peer_service.inner_service.loop
         )
         return loopchain_pb2.CommonReply(response_code=message_code.Response.success, message="success")

--- a/loopchain/protos/loopchain.proto
+++ b/loopchain/protos/loopchain.proto
@@ -54,6 +54,7 @@ service PeerService {
     rpc BlockSync (BlockSyncRequest) returns (BlockSyncReply) {}
     // Subscribe 후 broadcast 받는 인터페이스는 Announce- 로 시작한다.
     rpc AnnounceUnconfirmedBlock (BlockSend) returns (CommonReply) {}
+    rpc AnnounceUnrecordedBlock (BlockSend) returns (CommonReply) {}
     rpc AnnounceNewBlockForVote (NewBlockSend) returns (CommonReply) {}
     rpc AnnounceConfirmedBlock (BlockAnnounce) returns (CommonReply) {}
     // Test 검증을 위한 인터페이스


### PR DESCRIPTION
Edit logic to be ignored the `unrecorded block` always even though it is made by the 1st leader of a new term.

- Add logic and message to process the `AnnounceUnrecordedBlock`.
- Remove some logs
- Edit some docstrings.