### PR TITLE
[LC-536] Call `new_epoch()` during consensus per block only once, after adding a block in a blockchain.

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -456,6 +456,7 @@ class BlockChain:
             self._increase_made_block_count(block)  # must do this before self.__last_block = block
             self.__last_block = block
             self.__total_tx = next_total_tx
+            self.__block_manager.new_epoch()
 
             logging.info(
                 f"ADD BLOCK HEIGHT : {block.header.height} , "

--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
 
 class Epoch:
-    def __init__(self, block_manager, leader_id=None):
+    def __init__(self, block_manager: 'BlockManager', leader_id=None):
         self.__block_manager: BlockManager = block_manager
         self.__blockchain = block_manager.blockchain
         if self.__blockchain.last_block:
@@ -58,15 +58,6 @@ class Epoch:
     @property
     def complain_duration(self):
         return min((2 ** self.round) * conf.TIMEOUT_FOR_LEADER_COMPLAIN, conf.MAX_TIMEOUT_FOR_LEADER_COMPLAIN)
-
-    @staticmethod
-    def new_epoch(leader_id=None):
-        block_manager: BlockManager = ObjectManager().channel_service.block_manager
-        leader_id = leader_id or ObjectManager().channel_service.block_manager.get_next_leader(
-            block_manager.blockchain.latest_block)
-        new_epoch = Epoch(block_manager, leader_id)
-        # utils.logger.spam(f"new epoch height({new_epoch.height})")
-        return new_epoch
 
     def new_round(self, new_leader_id, round_=None):
         is_complained = round_ != 0

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -509,17 +509,12 @@ class ChannelService:
             logging.warning(f"in peer_service:reset_leader There is no peer by peer_id({new_leader_id})")
             return
 
-        utils.logger.spam(f"peer_service:reset_leader target({leader_peer.target}), complained={complained}")
+        utils.logger.spam(f"reset_leader target({leader_peer.target}), complained={complained}")
 
         self.peer_manager.set_leader_peer(leader_peer)
         if complained:
             self.__block_manager.blockchain.reset_leader_made_block_count()
             self.__block_manager.epoch.new_round(leader_peer.peer_id)
-        else:
-            self.__block_manager.epoch = Epoch.new_epoch(leader_peer.peer_id)
-
-        logging.info(
-            f"Epoch height({self.__block_manager.epoch.height}), leader ({self.__block_manager.epoch.leader_id})")
 
         if ChannelProperty().peer_id == leader_peer.peer_id:
             utils.logger.debug("Set Peer Type Leader!")

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -179,7 +179,6 @@ class ChannelStateMachine(object):
     def _subscribe_network_on_exit(self, *args, **kwargs):
         self.__channel_service.stop_subscribe_timer()
         self.__channel_service.stop_shutdown_timer_when_fail_subscribe()
-        self.__channel_service.block_manager.start_epoch()
 
     def _watch_on_enter(self, *args, **kwargs):
         loggers.get_preset().is_leader = False

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -719,6 +719,13 @@ class BlockManager:
 
         return max_height, unconfirmed_block_height, peer_stubs
 
+    def new_epoch(self):
+        if self.epoch:
+            new_leader_id = self.get_next_leader(self.blockchain.last_block)
+            new_leader = self.__channel_service.peer_manager.get_peer(new_leader_id)
+            self.epoch = Epoch.new_epoch(new_leader.peer_id)
+            logging.info(f"Epoch height({self.epoch.height}), leader ({self.epoch.leader_id})")
+
     def stop(self):
         # for reuse key value store when restart channel.
         self.blockchain.close_blockchain_store()

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -328,7 +328,7 @@ class BlockManager:
     def rebuild_block(self):
         self.blockchain.rebuild_transaction_count()
         self.blockchain.rebuild_made_block_count()
-        self.epoch = Epoch.new_epoch()
+        self.new_epoch()
 
         nid = self.blockchain.find_nid()
         if nid is None:
@@ -718,8 +718,7 @@ class BlockManager:
 
     def new_epoch(self):
         new_leader_id = self.get_next_leader(self.blockchain.last_block)
-        new_leader = self.__channel_service.peer_manager.get_peer(new_leader_id)
-        self.epoch = Epoch.new_epoch(new_leader.peer_id)
+        self.epoch = Epoch(self, new_leader_id)
         logging.info(f"Epoch height({self.epoch.height}), leader ({self.epoch.leader_id})")
 
     def stop(self):

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -328,6 +328,7 @@ class BlockManager:
     def rebuild_block(self):
         self.blockchain.rebuild_transaction_count()
         self.blockchain.rebuild_made_block_count()
+        self.epoch = Epoch.new_epoch()
 
         nid = self.blockchain.find_nid()
         if nid is None:
@@ -651,10 +652,6 @@ class BlockManager:
 
         return True
 
-    def start_epoch(self):
-        self.epoch = Epoch.new_epoch()
-        util.logger.debug(f"start epoch epoch leader({self.epoch.leader_id})")
-
     def get_next_leader(self, block: Block) -> Optional[str]:
         if block.header.prep_changed:
             next_leader = self.blockchain.get_first_leader_of_next_reps(block)
@@ -720,11 +717,10 @@ class BlockManager:
         return max_height, unconfirmed_block_height, peer_stubs
 
     def new_epoch(self):
-        if self.epoch:
-            new_leader_id = self.get_next_leader(self.blockchain.last_block)
-            new_leader = self.__channel_service.peer_manager.get_peer(new_leader_id)
-            self.epoch = Epoch.new_epoch(new_leader.peer_id)
-            logging.info(f"Epoch height({self.epoch.height}), leader ({self.epoch.leader_id})")
+        new_leader_id = self.get_next_leader(self.blockchain.last_block)
+        new_leader = self.__channel_service.peer_manager.get_peer(new_leader_id)
+        self.epoch = Epoch.new_epoch(new_leader.peer_id)
+        logging.info(f"Epoch height({self.epoch.height}), leader ({self.epoch.leader_id})")
 
     def stop(self):
         # for reuse key value store when restart channel.

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -105,13 +105,8 @@ class ConsensusSiever(ConsensusBase):
         self._blockchain.add_block(block, confirm_info=vote.votes)
         self._block_manager.candidate_blocks.remove_block(block.header.hash)
         self._blockchain.last_unconfirmed_block = None
-        next_leader = self._block_manager.get_next_leader(block)
-        self._block_manager.epoch = Epoch.new_epoch(next_leader)
 
     def _makeup_new_block(self, block_version, complain_votes, block_hash, skip_add_tx=False):
-        if not self._block_manager.epoch.complained_result:
-            self._block_manager.epoch = Epoch.new_epoch(ChannelProperty().peer_id)
-
         self._blockchain.last_unconfirmed_block = None
         dumped_votes = self._blockchain.find_confirm_info_by_hash(block_hash)
 
@@ -365,6 +360,6 @@ class ConsensusSiever(ConsensusBase):
         if timer_key in timer_service.timer_list:
             timer_service.stop_timer(timer_key)
 
-    def __broadcast_block(self, block: 'Block', is_unrecorded_block: bool):
+    def __broadcast_block(self, block: 'Block', is_unrecorded_block: bool = False):
         broadcast_func = partial(self._block_manager.broadcast_send_unconfirmed_block, block, is_unrecorded_block)
         self.__start_broadcast_send_unconfirmed_block_timer(broadcast_func)


### PR DESCRIPTION
Call `new_epoch()` during consensus per block only once, after adding a block in a blockchain.

- Add a default value of `is_unrecorded_block` in `__broadcast_block()`.