### PR TITLE
[LC-681] Remove `r` command

### DIFF
--- a/docs/5. run/run_citizen_node.md
+++ b/docs/5. run/run_citizen_node.md
@@ -11,7 +11,7 @@ For detailed information about ICON Network, Pleases refer to [ICON Network](htt
 This command will enable ICON citizen node on Testnet network, running on port **9000**.
 
 ```bash
-$ loop -r testnet
+$ loop --testnet
 ```
 
 Once it's connected to the network, it will start to sync all the blocks on the ICON testnet network.
@@ -200,7 +200,7 @@ For more JSON-RPC APIs provided by tbears, please go to [Command-line Interfaces
 This command below will enable ICON citizen node on Mainnet network, running on port **9100**.
 
 ```bash
-$ loop -r mainnet
+$ loop --mainnet
 ```
 
 Once it's connected to the network, it will start to sync all the blocks on the ICON mainnet network.

--- a/loopchain/baseservice/rest_service.py
+++ b/loopchain/baseservice/rest_service.py
@@ -37,6 +37,8 @@ class RestService(CommonProcess):
         args = ['python3', '-m', 'loopchain', 'rest', '-p', str(self._port)]
         args += command_arguments.get_raw_commands_by_filter(
             command_arguments.Type.AMQPKey,
+            command_arguments.Type.MainNet,
+            command_arguments.Type.TestNet,
             command_arguments.Type.RadioStationTarget
         )
         server = CommonSubprocess(args)

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -355,6 +355,8 @@ class ChannelService:
                 command_arguments.Type.AMQPKey,
                 command_arguments.Type.Develop,
                 command_arguments.Type.ConfigurationFilePath,
+                command_arguments.Type.MainNet,
+                command_arguments.Type.TestNet,
                 command_arguments.Type.RadioStationTarget
             )
             self.__score_container = CommonSubprocess(process_args)

--- a/loopchain/launcher.py
+++ b/loopchain/launcher.py
@@ -63,11 +63,13 @@ def main(argv):
         parser.exit()
 
     command_arguments.set_raw_commands(args)
+    if args.radio_station_target:
+        logging.warning(f"Deprecated: {command_arguments.attributes[command_arguments.Type.RadioStationTarget].help}")
 
-    if args.radio_station_target == 'testnet':
+    if args.radio_station_target == 'testnet' or args.testnet:
         args.radio_station_target = conf.URL_CITIZEN_TESTNET
         args.configure_file_path = conf.CONF_PATH_LOOPCHAIN_TESTNET
-    elif args.radio_station_target == 'mainnet':
+    elif args.radio_station_target == 'mainnet' or args.mainnet:
         args.radio_station_target = conf.URL_CITIZEN_MAINNET
         args.configure_file_path = conf.CONF_PATH_LOOPCHAIN_MAINNET
 
@@ -129,9 +131,9 @@ def start_as_rest_server(args):
     api_port = int(args.port) + conf.PORT_DIFF_REST_SERVICE_CONTAINER
     conf_path = conf.CONF_PATH_ICONRPCSERVER_DEV
 
-    if args.radio_station_target == conf.URL_CITIZEN_TESTNET:
+    if args.radio_station_target == conf.URL_CITIZEN_TESTNET or args.testnet:
         conf_path = conf.CONF_PATH_ICONRPCSERVER_TESTNET
-    elif args.radio_station_target == conf.URL_CITIZEN_MAINNET:
+    elif args.radio_station_target == conf.URL_CITIZEN_MAINNET or args.mainnet:
         conf_path = conf.CONF_PATH_ICONRPCSERVER_MAINNET
 
     additional_conf = {
@@ -160,9 +162,9 @@ def start_as_score(args):
     amqp_key = args.amqp_key or conf.AMQP_KEY
     conf_path = conf.CONF_PATH_ICONSERVICE_DEV
 
-    if args.radio_station_target == conf.URL_CITIZEN_TESTNET:
+    if args.radio_station_target == conf.URL_CITIZEN_TESTNET or args.testnet:
         conf_path = conf.CONF_PATH_ICONSERVICE_TESTNET
-    elif args.radio_station_target == conf.URL_CITIZEN_MAINNET:
+    elif args.radio_station_target == conf.URL_CITIZEN_MAINNET or args.mainnet:
         conf_path = conf.CONF_PATH_ICONSERVICE_MAINNET
 
     network_type = conf_path.split('/')[-2]

--- a/loopchain/peer/peer_service.py
+++ b/loopchain/peer/peer_service.py
@@ -252,6 +252,8 @@ class PeerService:
                 command_arguments.Type.AMQPTarget,
                 command_arguments.Type.AMQPKey,
                 command_arguments.Type.ConfigurationFilePath,
+                command_arguments.Type.MainNet,
+                command_arguments.Type.TestNet,
                 command_arguments.Type.RadioStationTarget
             )
 

--- a/loopchain/utils/command_arguments/__init__.py
+++ b/loopchain/utils/command_arguments/__init__.py
@@ -30,6 +30,8 @@ class Type(IntEnum):
     AMQPTarget = 9
     AMQPKey = 10
     Version = 11
+    MainNet = 12
+    TestNet = 13
 
 
 class Attribute:
@@ -49,12 +51,18 @@ class Attribute:
 
         return [self.names[0], str(value)]
 
+    @property
+    def help(self):
+        return self.kwargs.get("help")
+
 
 types_by_names = {
     "service_type": Type.ServiceType,
     "port": Type.Port,
     "configure_file_path": Type.ConfigurationFilePath,
     "radio_station_target": Type.RadioStationTarget,
+    "mainnet": Type.MainNet,
+    "testnet": Type.TestNet,
     "develop": Type.Develop,
     "agent_pin": Type.AgentPin,
     "cert": Type.Cert,
@@ -70,6 +78,12 @@ attributes = {
         Attribute("service_type", type=str, default='citizen', nargs='?',
                   help="loopchain service to start [peer|citizen|tool|admin]"),
 
+    Type.MainNet:
+        Attribute("--mainnet", action="store_true", help="Connect to mainnet"),
+
+    Type.TestNet:
+        Attribute("--testnet", action="store_true", help="Connect to testnet"),
+
     Type.Port:
         Attribute("-p", "--port",
                   help="port of Service itself"),
@@ -79,12 +93,15 @@ attributes = {
                   help="json configure file path"),
 
     # options for peer
-    # r, rs, radiostation means higher layer node.
     Type.RadioStationTarget:
         Attribute("-r", "--radio_station_target",
-                  help="[IP Address of Radio Station]:[PORT number of Radio Station], "
-                       "[IP Address of Sub Radio Station]:[PORT number of Sub Radio Station] "
-                       "or just [IP Address of Radio Station]"),
+                  help="\n"
+                       "******************************************************************************\n"
+                       "*   Option `-r` is deprecated and will be removed very soon.                 *\n"
+                       "*   You need to set radiostation targets into configuration file.            *\n"
+                       "*   Please read examples under `./conf` to make your own peer configuration. *\n"
+                       "******************************************************************************\n"),
+
     Type.Develop:
         Attribute("-d", "--develop", action="store_true",
                   help="set log level to SPAM (low develop mode)"),


### PR DESCRIPTION
Remove rs_target option at command 
> __NOTE__: (maintain `-r` option for legacy support  and it will be deprecated soon)

to connect mainnet: `$ loop --mainnet`
to connect testnet: `$ loop --testnet`