### PR TITLE
[LC-676] Refactoring NodeSubscriber

### DIFF
--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -122,6 +122,14 @@ class NodeSubscriber:
             loop=MessageQueueService.loop
         )
 
+    async def _subscribe_request(self, block_height):
+        request = Request(
+            method="node_ws_Subscribe",
+            height=block_height,
+            peer_id=ChannelProperty().peer_id
+        )
+        await self._websocket.send(json.dumps(request))
+
     async def _subscribe_loop(self, websocket: WebSocketClientProtocol):
         while True:
             if self._exception:

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -114,6 +114,14 @@ class NodeSubscriber:
         finally:
             await self.close()
 
+    async def _prepare_connection(self, event):
+        self._subscribe_event = event
+        self._websocket: WebSocketClientProtocol = await websockets.connect(
+            uri=self._target_uri,
+            max_size=4 * conf.MAX_TX_SIZE_IN_BLOCK,
+            loop=MessageQueueService.loop
+        )
+
     async def _subscribe_loop(self, websocket: WebSocketClientProtocol):
         while True:
             if self._exception:

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -122,6 +122,19 @@ class NodeSubscriber:
             loop=MessageQueueService.loop
         )
 
+    async def _handshake(self, block_height):
+        try:
+            await self._subscribe_request(block_height)
+            await self._recv_until_timeout()
+        except Exception as e:
+            logging.debug(f"Exception raised during handshake step: {e}", exc_info=True)
+            await self.close()
+        else:
+            logging.debug(f"Websocket connection is completed, with id({id(self._websocket)})")
+        finally:
+            # set subscribe_event to transit the state to Watch.
+            self._subscribe_event.set()
+
     async def _subscribe_request(self, block_height):
         request = Request(
             method="node_ws_Subscribe",

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -152,6 +152,18 @@ class NodeSubscriber:
 
         return response_dict
 
+    async def subscribe_loop(self):
+        try:
+            await self._subscribe_loop()
+        except AnnounceNewBlockError as e:
+            logging.error(f"{type(e)} during subscribe, caused by: {e}")
+            raise e
+        except Exception as e:
+            logging.info(f"{type(e)} during subscribe, caused by: {e}")
+            raise ConnectionError
+        finally:
+            await self.close()
+
     async def _subscribe_loop(self, websocket: WebSocketClientProtocol):
         while True:
             if self._exception:

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -130,6 +130,15 @@ class NodeSubscriber:
         )
         await self._websocket.send(json.dumps(request))
 
+    async def _recv_until_timeout(self) -> dict:
+        response: bytes = await asyncio.wait_for(
+            fut=self._websocket.recv(),
+            timeout=2 * conf.CONNECTION_RETRY_TIMEOUT_TO_RS
+        )
+        response_dict = convert_reponse_to_dict(response)
+
+        return response_dict
+
     async def _subscribe_loop(self, websocket: WebSocketClientProtocol):
         while True:
             if self._exception:

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -64,7 +64,6 @@ class NodeSubscriber:
         scheme = 'wss' if ('https://' in rs_target) else 'ws'
         netloc = parse.urlparse(rs_target).netloc
         self._target_uri = f"{scheme}://{netloc}/api/ws/{channel}"
-        self._exception = None
         self._websocket: WebSocketClientProtocol = None
         self._subscribe_event: Event = None
 
@@ -74,6 +73,7 @@ class NodeSubscriber:
         logging.debug(f"websocket target uri : {self._target_uri}")
 
     def __del__(self):
+        # TODO: Check usage
         if self._websocket is not None:
             utils.logger.warning(f"Have to close before delete NodeSubscriber instance({self})")
 
@@ -85,37 +85,13 @@ class NodeSubscriber:
                 logging.debug(f"Closing websocket connection to {self._target_uri}...")
                 await websocket.close()
 
-    async def subscribe(self, block_height, event: Event):
-        self._exception = None
+    async def start(self, event, block_height):
         self._subscribe_event = event
-        await self.close()
+        await self._prepare_connection()
+        await self._handshake(block_height)
+        await self._run()
 
-        try:
-            # set websocket payload maxsize to 4MB.
-            self._websocket: WebSocketClientProtocol = await websockets.connect(
-                uri=self._target_uri,
-                max_size=4 * conf.MAX_TX_SIZE_IN_BLOCK,
-                loop=MessageQueueService.loop
-            )
-            logging.debug(f"Websocket connection is completed, with id({id(self._websocket)})")
-            request = Request(
-                method="node_ws_Subscribe",
-                height=block_height,
-                peer_id=ChannelProperty().peer_id
-            )
-            await self._websocket.send(json.dumps(request))
-            await self._subscribe_loop(self._websocket)
-        except AnnounceNewBlockError as e:
-            logging.error(f"{type(e)} during subscribe, caused by: {e}")
-            raise e
-        except Exception as e:
-            logging.info(f"{type(e)} during subscribe, caused by: {e}")
-            raise ConnectionError
-        finally:
-            await self.close()
-
-    async def _prepare_connection(self, event):
-        self._subscribe_event = event
+    async def _prepare_connection(self):
         self._websocket: WebSocketClientProtocol = await websockets.connect(
             uri=self._target_uri,
             max_size=4 * conf.MAX_TX_SIZE_IN_BLOCK,
@@ -152,43 +128,24 @@ class NodeSubscriber:
 
         return response_dict
 
-    async def subscribe_loop(self):
+    async def _run(self):
         try:
             await self._subscribe_loop()
         except AnnounceNewBlockError as e:
             logging.error(f"{type(e)} during subscribe, caused by: {e}")
-            raise e
+            raise e  # TODO: Check that exceptions to be raised or not.
         except Exception as e:
             logging.info(f"{type(e)} during subscribe, caused by: {e}")
-            raise ConnectionError
+            raise ConnectionError  # TODO: Check that exceptions to be raised or not.
         finally:
             await self.close()
 
-    async def _subscribe_loop(self, websocket: WebSocketClientProtocol):
+    async def _subscribe_loop(self):
         while True:
-            if self._exception:
-                raise self._exception
-
-            try:
-                response = await asyncio.wait_for(
-                    fut=websocket.recv(),
-                    timeout=2 * conf.TIMEOUT_FOR_WS_HEARTBEAT
-                )
-            except asyncio.TimeoutError:
-                self._exception = asyncio.TimeoutError('Timed out for websocket recv')
-                continue
-            else:
-                response_dict = json.loads(response)
-                await ws_methods.dispatch(response_dict)
+            response_dict: dict = await self._recv_until_timeout()
+            await ws_methods.dispatch(response_dict)
 
     async def node_ws_PublishNewBlock(self, **kwargs):
-        if 'error' in kwargs:
-            if kwargs.get('code') in CONNECTION_FAIL_CONDITIONS:
-                self._exception = ConnectionError(kwargs['error'])
-                return
-            else:
-                return ObjectManager().channel_service.shutdown_peer(message=kwargs.get('error'))
-
         block_dict, votes_dumped = kwargs.get('block'), kwargs.get('confirm_info', '')
         try:
             votes_serialized = json.loads(votes_dumped)
@@ -213,7 +170,7 @@ class NodeSubscriber:
                                       blockchain.get_expected_generator(confirmed_block.header.peer_id),
                                       reps_getter=reps_getter)
             except Exception as e:
-                self._exception = AnnounceNewBlockError(f"error: {type(e)}, message: {str(e)}")
+                raise AnnounceNewBlockError(f"error: {type(e)}, message: {str(e)}")
             else:
                 logging.debug(f"add_confirmed_block height({confirmed_block.header.height}), "
                               f"hash({confirmed_block.header.hash.hex()}), votes_dumped({votes_dumped})")
@@ -224,19 +181,8 @@ class NodeSubscriber:
 
     async def node_ws_PublishHeartbeat(self, **kwargs):
         def _callback(exception):
-            self._exception = exception
+            raise exception
 
-        if 'error' in kwargs:
-            _callback(ConnectionError(kwargs['error']))
-            return
-
-        if not self._subscribe_event.is_set():
-            # set subscribe_event to transit the state to Watch.
-            self._subscribe_event.set()
-
-        await self._reset_heartbeat_timer(_callback)
-
-    async def _reset_heartbeat_timer(self, _callback):
         timer_key = TimerService.TIMER_KEY_WS_HEARTBEAT
         timer_service = ObjectManager().channel_service.timer_service
         if timer_key in timer_service.timer_list:

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -419,7 +419,7 @@ class ChannelService:
         utils.logger.spam(f"try subscribe_call_by_citizen target({ChannelProperty().rest_target})")
 
         # try websocket connection, and handle exception in callback
-        asyncio.ensure_future(self.__node_subscriber.subscribe(
+        asyncio.ensure_future(self.__node_subscriber.start(
             block_height=self.__block_manager.blockchain.block_height,
             event=subscribe_event,
         ), loop=MessageQueueService.loop).add_done_callback(_handle_exception)

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup_options = {
     'setup_requires': setup_requires,
     'install_requires': install_requires,
     'extras_require': {
-        'tests': ['iconsdk==1.1.0', 'pytest>=4.6.3', 'pytest-xprocess>=0.12.1', "pytest-benchmark"],
+        'tests': ['iconsdk==1.1.0', 'pytest>=4.6.3', 'pytest-xprocess>=0.12.1', "pytest-benchmark", "pytest-mock",
+                  "pytest-asyncio"],
     },
     'entry_points': {
         'console_scripts': [

--- a/testcase/unittest/baseservice/test_node_subscriber.py
+++ b/testcase/unittest/baseservice/test_node_subscriber.py
@@ -1,0 +1,209 @@
+import asyncio
+import json
+import urllib
+
+import pytest
+import websockets
+
+from loopchain.baseservice import ObjectManager
+from loopchain.baseservice.node_subscriber import NodeSubscriber, _check_error_in_response
+from loopchain.protos import message_code
+
+from loopchain.blockchain import AnnounceNewBlockError
+
+
+@pytest.fixture
+def mock_ws(mocker):
+    class MockWebSocket:
+        def __init__(self, mocker_fixture):
+            self.mock_send = mocker_fixture.MagicMock()
+            msg_from_rs = json.dumps({"test": "success message from rs_target!"})
+            self.mock_recv = mocker_fixture.MagicMock(return_value=msg_from_rs)
+            self.mock_close = mocker_fixture.MagicMock()
+
+        @property
+        def closed(self) -> bool:
+            """Fake status for websocket connection.
+
+            When initialized, returns True (Connection not established).
+            When any of send or recv is called (for faking handshake steps), returns True (Connection established).
+            When close is called, returns True (Connnection closed).
+            """
+            is_sent = self.mock_send.called
+            is_recv = self.mock_send.called
+            is_closed = self.mock_close.called
+
+            if is_closed:
+                return True
+            if is_sent or is_recv:
+                return False
+            else:
+                return True
+
+        async def send(self, request):
+            self.mock_send()
+
+            return True
+
+        async def recv(self):
+            returned_value = self.mock_recv()
+            return returned_value
+
+        async def close(self):
+            self.mock_close()
+            return True
+
+    return MockWebSocket(mocker)
+
+
+@pytest.fixture
+def node_subscriber():
+    channel = "channel"
+    rs_target = "https://test.com"
+
+    return NodeSubscriber(channel, rs_target)
+
+
+class TestHelper:
+    @pytest.mark.parametrize("response_dict", [
+        {"error": "test", "code": message_code.Response.fail_subscribe_limit},
+        {"error": "test", "code": message_code.Response.fail_connection_closed},
+    ])
+    def test_acceptable_errors_in_response(self, response_dict):
+        with pytest.raises(ConnectionError):
+            _check_error_in_response(response_dict)
+
+    @pytest.mark.parametrize("response_dict", [
+        {"error": "test", "code": message_code.Response.fail},
+    ])
+    def test_critical_errors_in_in_response(self, response_dict, mocker):
+        class MockChannelService:
+            pass
+
+        mock_channel = MockChannelService()
+        mock_channel.shutdown_peer = mocker.MagicMock()
+        ObjectManager().channel_service = mock_channel
+
+        _check_error_in_response(response_dict)
+        assert mock_channel.shutdown_peer.called
+
+    @pytest.mark.parametrize("rs_target, expected_scheme", [
+        ("https://test.com", "wss"),
+        ("http://test.com", "ws"),
+        ("fake-scheme://test.com", "ws"),
+    ])
+    def test_target_uri_has_valid_websocket_scheme(self, rs_target, expected_scheme):
+        channel = "channel"
+        node_subscriber = NodeSubscriber(channel, rs_target)
+
+        target_uri = node_subscriber._target_uri
+        scheme = urllib.parse.urlparse(target_uri).scheme
+
+        assert scheme == expected_scheme
+
+
+@pytest.mark.asyncio
+class TestNodeSubscriberBasic:
+    async def test_init_connection(self, node_subscriber, monkeypatch, mock_ws):
+        async def mock_connect(*args, **kwargs):
+            return mock_ws
+        node_subscriber._websocket = "a"
+
+        with monkeypatch.context() as m:
+            m.setattr(websockets, "connect", mock_connect)
+            await node_subscriber._prepare_connection()
+
+        assert node_subscriber._websocket == mock_ws
+
+    async def test_response_msg_contains_error(self, node_subscriber, mock_ws):
+        response_msg = {
+            "error": "rs_target says an exception raised!",
+            "code": message_code.Response.fail_subscribe_limit
+        }
+        mock_ws.mock_recv.return_value = json.dumps(response_msg)
+        node_subscriber._websocket = mock_ws
+        node_subscriber._subscribe_event = asyncio.Event()
+
+        with pytest.raises(ConnectionError):
+            await node_subscriber._recv_until_timeout()
+
+
+@pytest.mark.asyncio
+class TestNodeSubscriberHandShake:
+    async def test_handshake_success(self, node_subscriber, mock_ws):
+        node_subscriber._websocket = mock_ws
+        node_subscriber._subscribe_event = asyncio.Event()
+        assert mock_ws.closed
+
+        await node_subscriber._handshake(block_height=1)
+        assert mock_ws.mock_send.called
+        assert mock_ws.mock_recv.called
+        assert not mock_ws.closed
+
+    async def test_handshake_failure_in_request_ensures_ws_close(self, node_subscriber, mock_ws):
+        mock_ws.mock_send.side_effect = ConnectionError("Handshake error in send!")
+        node_subscriber._websocket = mock_ws
+        assert mock_ws.closed
+
+        with pytest.raises(ConnectionError):
+            await node_subscriber._handshake(block_height=1)
+
+        assert mock_ws.closed
+
+    async def test_handshake_failure_in_response_ensures_ws_close(self, node_subscriber, mock_ws):
+        mock_ws.mock_recv.side_effect = ConnectionError("Handshake error in recv!")
+        node_subscriber._websocket = mock_ws
+        assert mock_ws.closed
+
+        with pytest.raises(ConnectionError):
+            await node_subscriber._handshake(block_height=1)
+
+        assert mock_ws.closed
+
+    @pytest.mark.parametrize("code", [
+        message_code.Response.fail_subscribe_limit, message_code.Response.fail_connection_closed
+    ])
+    async def test_handshake_failure_by_returned_conn_fail_msgs_ensures_ws_close(self, node_subscriber, mock_ws, code):
+        mock_msg = {
+            "error": "rs_target says exception msg in handshake stage!",
+            "code": code
+        }
+        mock_ws.mock_recv.return_value = json.dumps(mock_msg)
+        node_subscriber._websocket = mock_ws
+        assert mock_ws.closed
+
+        with pytest.raises(ConnectionError):
+            await node_subscriber._handshake(block_height=1)
+
+        assert mock_ws.closed
+
+
+@pytest.mark.asyncio
+class TestNodeSubscriberFunctional:
+    @pytest.mark.parametrize("to_be_raised_exc, expected_exc", [
+        (AnnounceNewBlockError, AnnounceNewBlockError),
+        (RuntimeError, ConnectionError)
+    ])
+    async def test_subscribe_loop_failure_ensures_ws_close(self, node_subscriber, mock_ws,
+                                                           to_be_raised_exc, expected_exc):
+        async def mock_recv_until_timeout(*args, **kwargs):
+            raise to_be_raised_exc
+
+        node_subscriber._websocket = mock_ws
+        mock_ws.mock_send()
+        mock_ws.mock_recv()
+        assert not mock_ws.closed
+
+        node_subscriber._recv_until_timeout = mock_recv_until_timeout
+        with pytest.raises(expected_exc):
+            await node_subscriber._run()
+
+        assert mock_ws.closed
+
+    @pytest.mark.skip(reason="...")
+    async def test_node_ws_PublishNewBlock(self):
+        pass
+
+    @pytest.mark.skip(reason="Tested in TimerService")
+    async def test_node_ws_PublishHeartbeat(self):
+        pass


### PR DESCRIPTION
**This is a child side (those who is requesting) between connection. (PARENT CODE: https://github.com/icon-project/icon-rpc-server/pull/106)**
> Two PRs are coupled but has no dependencies.

# Changes
- Split out methods to check error response
- Split out subscribe loop into 3 parts:
  1. prepare_connection: initialize properties to be in ready to connect rs_target.
  2. handshake: establish connection between nodes
  3. subscribe_loop: subscribe blocks and heartbeats.
- Exceptions no longer assigned and not delayed as a property, but raises immediately when something goes wrong.
- Add unit tests
 