### PR TITLE
[LC-685] Edit some code to support backward compatibility.

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -588,9 +588,11 @@ class BlockChain:
         if confirm_info:
             if isinstance(confirm_info, list):
                 confirm_info = json.dumps(BlockVotes.serialize_votes(confirm_info))
+            if isinstance(confirm_info, str):
+                confirm_info = confirm_info.encode('utf-8')
             batch.put(
                 BlockChain.CONFIRM_INFO_KEY + block_hash_encoded,
-                confirm_info.encode("utf-8")
+                confirm_info
             )
 
         if block.header.prev_hash:

--- a/loopchain/blockchain/votes/v0_1a/vote.py
+++ b/loopchain/blockchain/votes/v0_1a/vote.py
@@ -42,7 +42,8 @@ class BlockVote(BaseVote[bool]):
     def _deserialize(cls, data: dict):
         data_deserialized = super()._deserialize(data)
         data_deserialized["block_height"] = int(data["blockHeight"], 16)
-        data_deserialized["round_"] = data["round_"]
+        round_ = data.get("round_")
+        data_deserialized["round_"] = round_ if round_ else 0
         data_deserialized["block_hash"] = Hash32.fromhex(data["blockHash"])
         return data_deserialized
 
@@ -51,7 +52,7 @@ class BlockVote(BaseVote[bool]):
     def to_origin_data(cls, rep: ExternalAddress, timestamp: int, block_height: int, round_: int, block_hash: Hash32):
         origin_data = super().to_origin_data(rep, timestamp)
         origin_data["blockHeight"] = hex(block_height)
-        origin_data["round_"] = round_
+        origin_data["round_"] = round_ if round_ else 0
         origin_data["blockHash"] = block_hash.hex_0x() if block_hash is not None else None
         return origin_data
 
@@ -87,7 +88,8 @@ class LeaderVote(BaseVote[ExternalAddress]):
     def _deserialize(cls, data: dict):
         data_deserialized = super()._deserialize(data)
         data_deserialized["block_height"] = int(data["blockHeight"], 16)
-        data_deserialized["round_"] = data["round_"]
+        round_ = data.get("round_")
+        data_deserialized["round_"] = round_ if round_ else 0
         data_deserialized["old_leader"] = ExternalAddress.fromhex_address(data["oldLeader"])
         data_deserialized["new_leader"] = ExternalAddress.fromhex_address(data["newLeader"])
         return data_deserialized
@@ -98,7 +100,7 @@ class LeaderVote(BaseVote[ExternalAddress]):
                        old_leader: ExternalAddress, new_leader: ExternalAddress):
         origin_data = super().to_origin_data(rep, timestamp)
         origin_data["blockHeight"] = hex(block_height)
-        origin_data["round_"] = round_
+        origin_data["round_"] = round_ if round_ else 0
         origin_data["oldLeader"] = old_leader.hex_hx()
         origin_data["newLeader"] = new_leader.hex_hx()
         return origin_data

--- a/loopchain/blockchain/votes/v0_1a/vote.py
+++ b/loopchain/blockchain/votes/v0_1a/vote.py
@@ -11,8 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Union
 from dataclasses import dataclass
+from typing import Union
+
 from loopchain.blockchain.types import Hash32, ExternalAddress, Signature
 from loopchain.blockchain.votes import Vote as BaseVote
 from loopchain.crypto.signature import Signer
@@ -42,8 +43,7 @@ class BlockVote(BaseVote[bool]):
     def _deserialize(cls, data: dict):
         data_deserialized = super()._deserialize(data)
         data_deserialized["block_height"] = int(data["blockHeight"], 16)
-        round_ = data.get("round_")
-        data_deserialized["round_"] = round_ if round_ else 0
+        data_deserialized["round_"] = data.get("round_", 0)
         data_deserialized["block_hash"] = Hash32.fromhex(data["blockHash"])
         return data_deserialized
 
@@ -88,8 +88,7 @@ class LeaderVote(BaseVote[ExternalAddress]):
     def _deserialize(cls, data: dict):
         data_deserialized = super()._deserialize(data)
         data_deserialized["block_height"] = int(data["blockHeight"], 16)
-        round_ = data.get("round_")
-        data_deserialized["round_"] = round_ if round_ else 0
+        data_deserialized["round_"] = data.get("round_", 0)
         data_deserialized["old_leader"] = ExternalAddress.fromhex_address(data["oldLeader"])
         data_deserialized["new_leader"] = ExternalAddress.fromhex_address(data["newLeader"])
         return data_deserialized

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -772,7 +772,6 @@ class ChannelInnerTask:
             vote_serialized = json.loads(vote_dumped)
         except json.decoder.JSONDecodeError:
             util.logger.warning(f"This vote({vote_dumped}) may be from old version.")
-            raise
         else:
             vote = BlockVote.deserialize(vote_serialized)
             util.logger.debug(

--- a/loopchain/peer/peer_outer_service.py
+++ b/loopchain/peer/peer_outer_service.py
@@ -530,7 +530,7 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
     def VoteUnconfirmedBlock(self, request, context):
         channel_name = conf.LOOPCHAIN_DEFAULT_CHANNEL if request.channel == '' else request.channel
 
-        utils.logger.debug(f"VoteUnconfirmedBlock block_hash({request.vote})")
+        utils.logger.debug(f"VoteUnconfirmedBlock vote({request.vote})")
 
         channel_stub = StubCollection().channel_stubs[channel_name]
         asyncio.run_coroutine_threadsafe(

--- a/loopchain/peer/peer_outer_service.py
+++ b/loopchain/peer/peer_outer_service.py
@@ -183,7 +183,7 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
 
     def __status_update(self, channel, future):
         # update peer outer status cache by channel
-        utils.logger.spam(f"status_update channel({channel}) result({future.result()})")
+        # utils.logger.spam(f"status_update channel({channel}) result({future.result()})")
         self.__set_status_cache(channel, future.result())
 
     def __get_status_data(self, channel: str):
@@ -493,8 +493,14 @@ class PeerOuterService(loopchain_pb2_grpc.PeerServiceServicer):
         """
         channel_name = conf.LOOPCHAIN_DEFAULT_CHANNEL if request.channel == '' else request.channel
         channel_stub = StubCollection().channel_stubs[channel_name]
+
+        try:
+            round_ = request.round_
+        except AttributeError:
+            round_ = 0
+
         asyncio.run_coroutine_threadsafe(
-            channel_stub.async_task().announce_unconfirmed_block(request.block, request.round_),
+            channel_stub.async_task().announce_unconfirmed_block(request.block, round_),
             self.peer_service.inner_service.loop
         )
         return loopchain_pb2.CommonReply(response_code=message_code.Response.success, message="success")


### PR DESCRIPTION
- Add logic to support backward compatibility for `round`.
- Pre-encode if confirm_info's type is the `string`.
- Remove the `raise` to remove unnecessary traceback log.
- Edit a log.