### PR TITLE
[LC-693] add except_key for cleaning timer_service

### DIFF
--- a/loopchain/baseservice/timer_service.py
+++ b/loopchain/baseservice/timer_service.py
@@ -18,7 +18,7 @@ import threading
 import time
 import traceback
 from enum import Enum
-from typing import Dict, Callable, Awaitable, Union
+from typing import Dict, Callable, Awaitable, Union, Optional
 
 from loopchain import utils as util
 from loopchain.baseservice import CommonThread
@@ -241,8 +241,11 @@ class TimerService(CommonThread):
 
         self.__loop.call_soon_threadsafe(self.__loop.stop)
 
-    def clean(self):
+    def clean(self, except_key: Optional[str] = None):
+        temp_timer = self.__timer_list.get(except_key)
         self.__timer_list = {}
+        if temp_timer is not None:
+            self.__timer_list[except_key] = temp_timer
 
     def run(self, e: threading.Event):
         e.set()

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -252,7 +252,7 @@ class ChannelService:
         return conf.NodeType.CitizenNode
 
     async def __clean_network(self):
-        self.__timer_service.clean()
+        self.__timer_service.clean(except_key=TimerService.TIMER_KEY_BROADCAST_SEND_UNCONFIRMED_BLOCK)
         self.__peer_manager.clear_peers()
         self.__rs_client = None
 


### PR DESCRIPTION
When role_switch to BlockGenerate to Watch, one has to broadcast unrecorded block by the  TIMER_KEY_BROADCAST_SEND_UNCONFIRMED_BLOCK timer. 
However, because of some timing issue, reset_network clears all remaining timer so that old leader cannot broadcast anything.
