### PR TITLE
[LC-703] fix bug in peer_loader calling GetLastBlock

### DIFF
--- a/loopchain/peermanager/peer_loader.py
+++ b/loopchain/peermanager/peer_loader.py
@@ -88,7 +88,7 @@ class PeerLoader:
 
     @staticmethod
     def _is_block_version_0_3(rs_client) -> bool:
-        version = rs_client.call("GetLastBlock").get('version')
+        version = rs_client.call(RestMethod.GetLastBlock).get('version')
         if version is not None:
             return version == '0.3'
         else:


### PR DESCRIPTION
While RestClient has been updated recently, there was a bug where calling rest call through RestClient by old method type.