### PR TITLE
[LC-719] Exclude block sync target if target_id is the block generator

### DIFF
--- a/loopchain/blockchain/exception.py
+++ b/loopchain/blockchain/exception.py
@@ -34,6 +34,11 @@ class BlockError(Exception):
     pass
 
 
+class InvalidBlockSyncTarget(Exception):
+    """Raises when the target is invalid to block sync"""
+    pass
+
+
 class BlockchainError(Exception):
     """블럭체인상에서 문제가 발생했을때 발생하는 에러
     """


### PR DESCRIPTION
In case of block diversion, the voters / citizens would not sync blocks from leader node.