### PR TITLE
[LC-759] Update peer config (MainNet block 0.3)

### DIFF
--- a/conf/mainnet/loopchain_conf.json
+++ b/conf/mainnet/loopchain_conf.json
@@ -2,7 +2,8 @@
   "CHANNEL_OPTION" : {
     "icon_dex": {
       "block_versions": {
-        "0.1a": 0
+        "0.1a": 0,
+        "0.3": 10324749
       },
       "hash_versions": {
         "genesis": 0,


### PR DESCRIPTION
# Goal
MainNet has been updated on its blocks (to version 0.3), but config is not updated.
This PR aims to add block 0.3 height, to avoid BlockSync failure at `"0.3": 10324749` height.