### PR TITLE
[LC-769] skip add tx when first make_up_block with complain_result

### DIFF
--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -179,7 +179,7 @@ class Epoch:
                      complain_votes: LeaderVotes,
                      prev_votes,
                      new_term: bool = False,
-                     is_unrecorded: bool = False):
+                     skip_add_tx: bool = False):
         last_block = self.__blockchain.last_unconfirmed_block or self.__blockchain.last_block
         block_height = last_block.header.height + 1
         block_version = self.__blockchain.block_versioner.get_version(block_height)
@@ -192,8 +192,8 @@ class Epoch:
         if new_term:
             block_builder.next_leader = None
             block_builder.reps = None
-        elif is_unrecorded:
-            utils.logger.debug(f"unrecorded block for height({self.height})")
+        elif skip_add_tx:
+            utils.logger.debug(f"skip_add_tx for block height({self.height})")
         else:
             self.__add_tx_to_block(block_builder)
 

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -168,8 +168,9 @@ class ConsensusSiever(ConsensusBase):
             else:
                 is_unrecorded_block = False
 
+            skip_add_tx = is_unrecorded_block or complained_result
             block_builder = self._block_manager.epoch.makeup_block(
-                complain_votes, last_block_vote_list, new_term, is_unrecorded_block)
+                complain_votes, last_block_vote_list, new_term, skip_add_tx)
             need_next_call = False
             try:
                 if complained_result or new_term:


### PR DESCRIPTION
Fix a bug that new leader after LeaderComplain cannot make block with `unconfirmed_tx` during LeaderComplain.