### PR TITLE
[LC-781] Reset preps_data in DB if score returns preps data

### DIFF
--- a/loopchain/baseservice/broadcast_scheduler.py
+++ b/loopchain/baseservice/broadcast_scheduler.py
@@ -328,6 +328,14 @@ class BroadcastScheduler(metaclass=abc.ABCMeta):
     def _put_command(self, command, params, block=False, block_timeout=None):
         raise NotImplementedError("_put_command function is interface method")
 
+    @property
+    def audience_reps_hash(self):
+        return self.__audience_reps_hash
+
+    @audience_reps_hash.setter
+    def audience_reps_hash(self, reps_hash):
+        self.__audience_reps_hash = reps_hash
+
     def add_schedule_listener(self, callback, commands: tuple):
         if not commands:
             raise ValueError("commands parameter is required")

--- a/loopchain/baseservice/broadcast_scheduler.py
+++ b/loopchain/baseservice/broadcast_scheduler.py
@@ -328,13 +328,8 @@ class BroadcastScheduler(metaclass=abc.ABCMeta):
     def _put_command(self, command, params, block=False, block_timeout=None):
         raise NotImplementedError("_put_command function is interface method")
 
-    @property
-    def audience_reps_hash(self):
-        return self.__audience_reps_hash
-
-    @audience_reps_hash.setter
-    def audience_reps_hash(self, reps_hash):
-        self.__audience_reps_hash = reps_hash
+    def reset_audience_reps_hash(self):
+        self.__audience_reps_hash = None
 
     def add_schedule_listener(self, callback, commands: tuple):
         if not commands:

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -1330,7 +1330,8 @@ class BlockChain:
         new_block = block_builder.build()
 
         # next_reps_hash can be referenced after build block
-        self.__write_preps_if_changed(next_prep=next_prep, next_reps_hash=new_block.header.next_reps_hash)
+        if next_prep:
+            self.__write_preps(preps=next_prep["preps"], next_reps_hash=new_block.header.next_reps_hash)
         self.__block_manager.set_old_block_hash(new_block.header.height, new_block.header.hash, _block.header.hash)
 
         for tx_receipt in tx_receipts.values():
@@ -1339,9 +1340,8 @@ class BlockChain:
         self.__invoke_results[new_block.header.hash] = (tx_receipts, next_prep)
         return new_block, tx_receipts
 
-    def __write_preps_if_changed(self, next_prep: dict, next_reps_hash):
+    def __write_preps(self, preps: list, next_reps_hash):
         """Write prep data to DB."""
-        if next_prep:
-            ObjectManager().channel_service.broadcast_scheduler.audience_reps_hash = None
-            self.__cache_clear_roothash()
-            self.write_preps(next_reps_hash, next_prep["preps"])
+        self.write_preps(roothash=next_reps_hash, preps=preps)
+        self.__cache_clear_roothash()
+        ObjectManager().channel_service.broadcast_scheduler.reset_audience_reps_hash()

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -19,6 +19,7 @@ import threading
 import zlib
 from collections import Counter
 from enum import Enum
+from functools import lru_cache
 from os import linesep
 from types import MappingProxyType
 from typing import Union, List, cast, Optional, Tuple, Sequence, Mapping
@@ -29,7 +30,6 @@ from loopchain import configure as conf
 from loopchain import utils
 from loopchain.baseservice import ScoreResponse, ObjectManager
 from loopchain.baseservice.aging_cache import AgingCache
-from loopchain.baseservice.lru_cache import lru_cache
 from loopchain.blockchain.blocks import Block, BlockBuilder, BlockSerializer, BlockHeader, v0_1a
 from loopchain.blockchain.blocks import BlockProver, BlockProverType, BlockVersioner, NextRepsChangeReason
 from loopchain.blockchain.exception import *
@@ -393,20 +393,25 @@ class BlockChain:
             return json.dumps(votes_serialized).encode(encoding='UTF-8')
         return bytes()
 
-    @lru_cache(maxsize=4, valued_returns_only=True)
+    @lru_cache(maxsize=4)
     def find_preps_ids_by_roothash(self, roothash: Hash32) -> Tuple[str, ...]:
         preps = self.find_preps_by_roothash(roothash)
         return tuple([prep["id"] for prep in preps])
 
-    @lru_cache(maxsize=4, valued_returns_only=True)
+    @lru_cache(maxsize=4)
     def find_preps_addresses_by_roothash(self, roothash: Hash32) -> Tuple[ExternalAddress, ...]:
         preps_ids = self.find_preps_ids_by_roothash(roothash)
         return tuple([ExternalAddress.fromhex(prep_id) for prep_id in preps_ids])
 
-    @lru_cache(maxsize=4, valued_returns_only=True)
+    @lru_cache(maxsize=4)
     def find_preps_targets_by_roothash(self, roothash: Hash32) -> Mapping[str, str]:
         preps = self.find_preps_by_roothash(roothash)
         return MappingProxyType({prep["id"]: prep["p2pEndpoint"] for prep in preps})
+
+    def __cache_clear_roothash(self):
+        self.find_preps_ids_by_roothash.cache_clear()
+        self.find_preps_addresses_by_roothash.cache_clear()
+        self.find_preps_targets_by_roothash.cache_clear()
 
     @staticmethod
     def get_reps_hash_by_header(header: BlockHeader) -> Hash32:
@@ -1325,11 +1330,7 @@ class BlockChain:
         new_block = block_builder.build()
 
         # next_reps_hash can be referenced after build block
-        if next_prep:
-            # PREPs of unconfirmed block have to write to db in advance for the reset leader.
-            if not self.find_preps_addresses_by_roothash(new_block.header.next_reps_hash):
-                self.write_preps(new_block.header.next_reps_hash, next_prep['preps'])
-
+        self.__write_preps_if_changed(next_prep=next_prep, next_reps_hash=new_block.header.next_reps_hash)
         self.__block_manager.set_old_block_hash(new_block.header.height, new_block.header.hash, _block.header.hash)
 
         for tx_receipt in tx_receipts.values():
@@ -1337,3 +1338,10 @@ class BlockChain:
 
         self.__invoke_results[new_block.header.hash] = (tx_receipts, next_prep)
         return new_block, tx_receipts
+
+    def __write_preps_if_changed(self, next_prep: dict, next_reps_hash):
+        """Write prep data to DB."""
+        if next_prep:
+            ObjectManager().channel_service.broadcast_scheduler.audience_reps_hash = None
+            self.__cache_clear_roothash()
+            self.write_preps(next_reps_hash, next_prep["preps"])

--- a/testcase/unittest/test_lru_cache.py
+++ b/testcase/unittest/test_lru_cache.py
@@ -18,11 +18,11 @@
 
 import timeit
 import unittest
+from functools import lru_cache
 from functools import partial
 
 import loopchain.utils as util
 import testcase.unittest.test_util as test_util
-from loopchain.baseservice.lru_cache import lru_cache
 from loopchain.utils import loggers
 
 loggers.set_preset_type(loggers.PresetType.develop)
@@ -43,7 +43,7 @@ class TestLruCache(unittest.TestCase):
             ret.append(i ** i)
         return ret
 
-    @lru_cache(maxsize=4, valued_returns_only=True)
+    @lru_cache(maxsize=4)
     def get_big_list_with_cache(self, size):
         ret = []
         for i in range(size):
@@ -79,6 +79,25 @@ class TestLruCache(unittest.TestCase):
         util.logger.debug(f"returns_origin({returns_origin}), returns({returns}), returns2({returns2})")
         self.assertNotEqual(returns, returns2)
         self.assertEqual(returns2, returns_origin)
+
+    def test_cache_clear(self):
+        from unittest.mock import MagicMock
+        call_check_mock = MagicMock()
+
+        @lru_cache(maxsize=4)
+        def target_func():
+            call_check_mock()
+
+        target_func()
+        self.assertEqual(call_check_mock.call_count, 1)
+        target_func()
+        self.assertEqual(call_check_mock.call_count, 1)
+
+
+        # WHEN
+        target_func.cache_clear()
+        target_func()
+        self.assertEqual(call_check_mock.call_count, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
(Need for PR https://github.com/icon-project/icon-service/pull/386 to be merged first)
# Goal
- Update preps data if updated by icon-service.
- Use built-in lru_cache: Replace `base_service.lru_cache` as built-in `functoos.lru_cache`.