### PR TITLE
[LC-788] Remove blocking status check logic when create gRPC stubs

### DIFF
--- a/loopchain/baseservice/broadcast_scheduler.py
+++ b/loopchain/baseservice/broadcast_scheduler.py
@@ -204,10 +204,8 @@ class _Broadcaster:
     def __add_audience(self, audience_target):
         util.logger.debug(f"audience_target({audience_target})")
         if audience_target not in self.__audience:
-            stub_manager = StubManager.get_stub_manager_to_server(
+            stub_manager = StubManager(
                 audience_target, loopchain_pb2_grpc.PeerServiceStub,
-                time_out_seconds=conf.CONNECTION_RETRY_TIMEOUT_WHEN_INITIAL,
-                is_allow_null_stub=True,
                 ssl_auth_type=conf.GRPC_SSL_TYPE
             )
             self.__audience[audience_target] = stub_manager

--- a/loopchain/baseservice/stub_manager.py
+++ b/loopchain/baseservice/stub_manager.py
@@ -46,7 +46,7 @@ class StubManager:
             util.logger.spam(f"StubManager:__make_stub is_stub_reuse({is_stub_reuse}) self.__stub({self.__stub})")
 
             self.__stub, self.__channel = util.get_stub_to_server(
-                self.__target, self.__stub_type, is_check_status=False, ssl_auth_type=self.__ssl_auth_type)
+                self.__target, self.__stub_type, ssl_auth_type=self.__ssl_auth_type)
             self.__stub_update_time = datetime.datetime.now()
             if self.__stub:
                 self.__update_last_succeed_time()

--- a/loopchain/baseservice/stub_manager.py
+++ b/loopchain/baseservice/stub_manager.py
@@ -188,37 +188,3 @@ class StubManager:
         except Exception as e:
             logging.warning(f"stub_manager:check_status is Fail reason({e})")
             return False
-
-    @staticmethod
-    def get_stub_manager_to_server(target, stub_class, time_out_seconds=None,
-                                   is_allow_null_stub=False, ssl_auth_type=conf.SSLAuthType.none):
-        """gRPC connection to server
-
-        :return: stub manager to server
-        """
-
-        if time_out_seconds is None:
-            time_out_seconds = conf.CONNECTION_RETRY_TIMEOUT
-        stub_manager = StubManager(target, stub_class, ssl_auth_type)
-        start_time = timeit.default_timer()
-        duration = timeit.default_timer() - start_time
-
-        while duration < time_out_seconds:
-            try:
-                logging.debug("(stub_manager) get stub to server target: " + str(target))
-                stub_manager.stub.Request(loopchain_pb2.Message(
-                    code=message_code.Request.status,
-                    message="get_stub_manager_to_server"), conf.GRPC_TIMEOUT)
-                return stub_manager
-            except Exception as e:
-                if is_allow_null_stub:
-                    return stub_manager
-                logging.warning("Connect to Server Error(get_stub_manager_to_server): " + str(e))
-                logging.debug("duration(" + str(duration)
-                              + ") interval(" + str(conf.CONNECTION_RETRY_INTERVAL)
-                              + ") timeout(" + str(time_out_seconds) + ")")
-                # RETRY_INTERVAL 만큼 대기후 TIMEOUT 전이면 다시 시도
-                time.sleep(conf.CONNECTION_RETRY_INTERVAL)
-                duration = timeit.default_timer() - start_time
-
-        return None

--- a/loopchain/utils/__init__.py
+++ b/loopchain/utils/__init__.py
@@ -133,29 +133,16 @@ def get_stub_to_server(target, stub_class, time_out_seconds=None, is_check_statu
 
     :return: stub to server
     """
-    if time_out_seconds is None:
-        time_out_seconds = conf.CONNECTION_RETRY_TIMEOUT
+
     stub = None
     channel = None
-    start_time = timeit.default_timer()
-    duration = timeit.default_timer() - start_time
 
-    while stub is None and duration < time_out_seconds:
-        try:
-            logging.debug("(util) get stub to server target: " + str(target))
-            channel = GRPCHelper().create_client_channel(target, ssl_auth_type, conf.GRPC_SSL_KEY_LOAD_TYPE)
-            stub = stub_class(channel)
-            if is_check_status:
-                stub.Request(loopchain_pb2.Message(code=message_code.Request.status), conf.GRPC_TIMEOUT)
-        except Exception as e:
-            logging.warning("Connect to Server Error(get_stub_to_server): " + str(e))
-            logging.debug("duration(" + str(duration)
-                          + ") interval(" + str(conf.CONNECTION_RETRY_INTERVAL)
-                          + ") timeout(" + str(time_out_seconds) + ")")
-            # RETRY_INTERVAL 만큼 대기후 TIMEOUT 전이면 다시 시도
-            time.sleep(conf.CONNECTION_RETRY_INTERVAL)
-            duration = timeit.default_timer() - start_time
-            stub = None
+    try:
+        logging.debug("(util) get stub to server target: " + str(target))
+        channel = GRPCHelper().create_client_channel(target, ssl_auth_type, conf.GRPC_SSL_KEY_LOAD_TYPE)
+        stub = stub_class(channel)
+    except Exception as e:
+        logging.warning("Connect to Server Error(get_stub_to_server): " + str(e))
 
     return stub, channel
 

--- a/loopchain/utils/__init__.py
+++ b/loopchain/utils/__init__.py
@@ -127,8 +127,7 @@ def load_user_score(path):
     return _load_user_score_module(path, "UserScore")
 
 
-def get_stub_to_server(target, stub_class, time_out_seconds=None, is_check_status=True,
-                       ssl_auth_type: conf.SSLAuthType=conf.SSLAuthType.none):
+def get_stub_to_server(target, stub_class, ssl_auth_type: conf.SSLAuthType = conf.SSLAuthType.none):
     """gRPC connection to server
 
     :return: stub to server
@@ -138,11 +137,11 @@ def get_stub_to_server(target, stub_class, time_out_seconds=None, is_check_statu
     channel = None
 
     try:
-        logging.debug("(util) get stub to server target: " + str(target))
+        logging.debug(f"(util) get stub to server target: {target}")
         channel = GRPCHelper().create_client_channel(target, ssl_auth_type, conf.GRPC_SSL_KEY_LOAD_TYPE)
         stub = stub_class(channel)
     except Exception as e:
-        logging.warning("Connect to Server Error(get_stub_to_server): " + str(e))
+        logging.warning(f"Connect to Server Error(get_stub_to_server): {e}")
 
     return stub, channel
 

--- a/testcase/unittest/baseservice/test_broadcast.py
+++ b/testcase/unittest/baseservice/test_broadcast.py
@@ -3,7 +3,7 @@ from typing import List
 
 import pytest
 
-from loopchain.baseservice import StubManager, ObjectManager, BroadcastCommand
+from loopchain.baseservice import ObjectManager, BroadcastCommand
 from loopchain.baseservice.broadcast_scheduler import BroadcastScheduler, BroadcastSchedulerFactory
 from loopchain.baseservice.broadcast_scheduler import _Broadcaster, _BroadcastSchedulerMp, _BroadcastSchedulerThread
 
@@ -74,7 +74,7 @@ class TestBroadcaster:
 
     def test_handler_update_audience(self, bc, mocker):
         # Mock stubmanager to avoid actual grpc stub initialized.
-        mocker.patch.object(StubManager, "get_stub_manager_to_server")
+        mocker.patch("loopchain.baseservice.StubManager")
 
         audience_targets = [f"endpoint:{i}" for i in range(5)]
 
@@ -86,7 +86,7 @@ class TestBroadcaster:
 
     def test_handler_update_audience_twice_and_updated_with_new_audiences(self, bc, mocker):
         # Mock stubmanager to avoid actual grpc stub initialized.
-        mocker.patch.object(StubManager, "get_stub_manager_to_server")
+        mocker.patch("loopchain.baseservice.StubManager")
 
         expected_audience_count = 5
         new_audience_start_at = 2

--- a/testcase/unittest/test_util.py
+++ b/testcase/unittest/test_util.py
@@ -78,17 +78,14 @@ def run_peer_server_as_process_and_stub(
         except Exception as e:
             logging.warning(f"Exception in loop : {e}")
 
-    stub, channel = util.get_stub_to_server(target='localhost:' + str(port),
-                                            stub_class=loopchain_pb2_grpc.PeerServiceStub,
-                                            time_out_seconds=timeout)
+    stub, channel = util.get_stub_to_server(f"localhost:{port}", stub_class=loopchain_pb2_grpc.PeerServiceStub)
     return process, stub
 
 
 def run_peer_server_as_process_and_stub_manager(
         port, radiostation_port=conf.PORT_RADIOSTATION, group_id=None, score=None, timeout=None):
     process = run_peer_server_as_process(port, radiostation_port, group_id, score)
-    stub_manager = StubManager(
-        'localhost:' + str(port), loopchain_pb2_grpc.PeerServiceStub, ssl_auth_type=conf.GRPC_SSL_TYPE)
+    stub_manager = StubManager(f"localhost:{port}", loopchain_pb2_grpc.PeerServiceStub, ssl_auth_type=conf.GRPC_SSL_TYPE)
     return process, stub_manager
 
 
@@ -100,20 +97,21 @@ def run_radio_station_as_process(port):
 
 def run_radio_station_as_process_and_stub_manager(port, timeout=None):
     process = run_radio_station_as_process(port)
-    stub_manager = StubManager('localhost:' + str(port),
+    stub_manager = StubManager(f"localhost:{port}",
                                loopchain_pb2_grpc.RadioStationStub,
                                conf.GRPC_SSL_TYPE)
     util.request_server_in_time(stub_manager.stub.GetStatus, loopchain_pb2.StatusRequest(request=""))
     return process, stub_manager
 
 
-def run_radio_station_as_process_and_stub(port, timeout=None):
-    if timeout is None:
-        timeout = conf.TIMEOUT_FOR_RS_INIT
+def run_radio_station_as_process_and_stub(port):
     process = run_radio_station_as_process(port)
-    stub, channel = util.get_stub_to_server(target='localhost:' + str(port),
-                                            stub_class=loopchain_pb2_grpc.RadioStationStub,
-                                            time_out_seconds=timeout)
+
+    stub, channel = util.get_stub_to_server(
+        target=f"localhost:{port}",
+        stub_class=loopchain_pb2_grpc.RadioStationStub
+    )
+
     return process, stub
 
 

--- a/testcase/unittest/test_util.py
+++ b/testcase/unittest/test_util.py
@@ -87,7 +87,7 @@ def run_peer_server_as_process_and_stub(
 def run_peer_server_as_process_and_stub_manager(
         port, radiostation_port=conf.PORT_RADIOSTATION, group_id=None, score=None, timeout=None):
     process = run_peer_server_as_process(port, radiostation_port, group_id, score)
-    stub_manager = StubManager.get_stub_manager_to_server(
+    stub_manager = StubManager(
         'localhost:' + str(port), loopchain_pb2_grpc.PeerServiceStub, ssl_auth_type=conf.GRPC_SSL_TYPE)
     return process, stub_manager
 
@@ -100,8 +100,9 @@ def run_radio_station_as_process(port):
 
 def run_radio_station_as_process_and_stub_manager(port, timeout=None):
     process = run_radio_station_as_process(port)
-    stub_manager = StubManager.get_stub_manager_to_server(
-        'localhost:' + str(port), loopchain_pb2_grpc.RadioStationStub, conf.GRPC_SSL_TYPE)
+    stub_manager = StubManager('localhost:' + str(port),
+                               loopchain_pb2_grpc.RadioStationStub,
+                               conf.GRPC_SSL_TYPE)
     util.request_server_in_time(stub_manager.stub.GetStatus, loopchain_pb2.StatusRequest(request=""))
     return process, stub_manager
 


### PR DESCRIPTION
- Fix blocking logic in `get_stub_to_server` when you try to create gRPC stubs with a node in unresponsive state.
