### PR TITLE
[LC-768] Edit logic after `write_precommit_state`, which is determined by the result of itself.

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -672,7 +672,10 @@ class BlockChain:
                     self.get_invoke_func(invoke_block_height)(invoke_block, prev_invoke_block)
 
                 self._write_tx(invoke_block, receipts)
-                ObjectManager().channel_service.score_write_precommit_state(invoke_block)
+                try:
+                    ObjectManager().channel_service.score_write_precommit_state(invoke_block)
+                except Exception as e:
+                    utils.exit_and_msg(f"Fail to write precommit in the score.: {e}")
 
             return True
 

--- a/loopchain/blockchain/exception.py
+++ b/loopchain/blockchain/exception.py
@@ -159,6 +159,12 @@ class ScoreInvokeResultError(ScoreInvokeError):
     message_code = message_code.Response.fail_score_invoke_result
 
 
+class WritePrecommitStateError(Exception):
+    """Write Precommit State Error
+    """
+    pass
+
+
 class ChannelStatusError(Exception):
     """Channel is Dead
     """

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -25,7 +25,7 @@ from loopchain import utils
 from loopchain.baseservice import (BroadcastScheduler, BroadcastSchedulerFactory, BroadcastCommand,
                                    ObjectManager, CommonSubprocess, RestClient,
                                    NodeSubscriber, UnregisteredException, TimerService)
-from loopchain.blockchain.exception import AnnounceNewBlockError
+from loopchain.blockchain.exception import AnnounceNewBlockError, WritePrecommitStateError
 from loopchain.blockchain.blocks import Block
 from loopchain.blockchain.types import ExternalAddress, TransactionStatusInQueue
 from loopchain.channel.channel_inner_service import ChannelInnerService
@@ -553,7 +553,9 @@ class ChannelService:
         request = convert_params(request, ParamType.write_precommit_state)
 
         stub = StubCollection().icon_score_stubs[ChannelProperty().name]
-        stub.sync_task().write_precommit_state(request)
+        precommit_result: dict = stub.sync_task().write_precommit_state(request)
+        if "error" in precommit_result:
+            raise WritePrecommitStateError(precommit_result['error'])
 
         self.__block_manager.pop_old_block_hashes(block.header.height)
         return True


### PR DESCRIPTION
- Edit logic after `write_precommit_state`, which is determined by the result of itself.
- Add new exception class `WritePrecommitStateError`.