### PR TITLE
[LC-726] Edit logic to prevent confirmation of the previous block if it has a mismatch round with the current round of the node.

### DIFF
--- a/loopchain/blockchain/exception.py
+++ b/loopchain/blockchain/exception.py
@@ -125,6 +125,12 @@ class AnnounceNewBlockError(Exception):
     message_code = message_code.Response.fail_announce_block
 
 
+class RoundMismatch(Exception):
+    """
+    """
+    pass
+
+
 class BlockVersionNotMatch(Exception):
     def __init__(self, block_version: str, target_version: str, msg: str):
         super().__init__(msg)

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -14,7 +14,7 @@ from loopchain import configure as conf
 from loopchain.baseservice import TimerService, ObjectManager, Timer, RestMethod
 from loopchain.baseservice.aging_cache import AgingCache
 from loopchain.blockchain import (BlockChain, CandidateBlocks, Epoch, BlockchainError, NID, exception, NoConfirmInfo,
-                                  BlockHeightMismatch)
+                                  BlockHeightMismatch, RoundMismatch)
 from loopchain.blockchain.blocks import Block, BlockVerifier, BlockSerializer
 from loopchain.blockchain.blocks.block import NextRepsChangeReason
 from loopchain.blockchain.exception import (ConfirmInfoInvalid, ConfirmInfoInvalidAddedBlock,
@@ -1011,6 +1011,9 @@ class BlockManager:
             self.add_unconfirmed_block(unconfirmed_block, round_)
         except InvalidUnconfirmedBlock as e:
             self.candidate_blocks.remove_block(unconfirmed_block.header.hash)
+            util.logger.warning(e)
+        except RoundMismatch as e:
+            self.candidate_blocks.remove_block(unconfirmed_block.header.prev_hash)
             util.logger.warning(e)
         except UnrecordedBlock as e:
             util.logger.info(e)


### PR DESCRIPTION
- Edit logic to prevent confirmation of the previous block if it has a mismatch round with the current round of the node.