### PR TITLE
[LC-800] make block_height_sync_timer repeatable

### DIFF
--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -446,7 +446,8 @@ class BlockManager:
                 Timer(
                     target=timer_key,
                     duration=conf.GET_LAST_BLOCK_TIMER,
-                    callback=self.block_height_sync
+                    callback=self.block_height_sync,
+                    is_repeat=True
                 )
             )
 


### PR DESCRIPTION
In case of long ConnectionError, block_height_sync timer should be repeatable.