### PR TITLE
[LC-707] add NodePool and RestClientProxy

### DIFF
--- a/loopchain/baseservice/__init__.py
+++ b/loopchain/baseservice/__init__.py
@@ -26,3 +26,5 @@ from .node_subscriber import *
 from .slot_timer import *
 from .broadcast_scheduler import *
 from .rest_service import *
+from .node_pool import *
+

--- a/loopchain/baseservice/__init__.py
+++ b/loopchain/baseservice/__init__.py
@@ -27,4 +27,5 @@ from .slot_timer import *
 from .broadcast_scheduler import *
 from .rest_service import *
 from .node_pool import *
+from .rest_client_proxy import *
 

--- a/loopchain/baseservice/node_pool.py
+++ b/loopchain/baseservice/node_pool.py
@@ -1,0 +1,92 @@
+"""A management class for radiostation node pool"""
+
+import asyncio
+import logging
+from typing import Optional, Sequence, Iterator, Dict
+from urllib.parse import urlparse
+
+import time
+from itertools import cycle
+
+from loopchain import utils, configure as conf
+from loopchain.baseservice.rest_client import RestMethod, RestClient
+
+
+class NodePool:
+    def __init__(self, channel):
+        self.channel = channel
+        self._rest_client = RestClient(channel)
+        self._target: Optional[str] = None
+        self._nearest_targets: Optional[Iterator] = None
+
+        loop = asyncio.get_event_loop()
+        loop.create_task(self._find())
+
+    @property
+    def target(self):
+        return self._target
+
+    async def _find(self):
+        while True:
+            endpoints = self._get_all_endpoints()
+            self._nearest_targets = await self._find_nearest_endpoints(endpoints)
+            if self._nearest_targets:
+                min_latency_target = next(self._nearest_targets)['target']  # get first target
+                self._set_target(min_latency_target)
+            await asyncio.sleep(conf.CONNECTION_RETRY_TIMEOUT)
+
+    def find_next(self):
+        next_target = next(self._nearest_targets)['target']
+        logging.debug(f"switching target from({self._target}) to({next_target})")
+        self._set_target(next_target)
+
+    def _set_target(self, target):
+        self._target = self._normalize_target(target)
+        logging.info(f"NodePool setting target({self._target})")
+
+    def _get_all_endpoints(self):
+        endpoints: list = conf.CHANNEL_OPTION[self.channel].get('radiostations')
+        if not endpoints:
+            raise RuntimeError(f"no configurations for radiostations.")
+
+        endpoints = utils.convert_local_ip_to_private_ip(endpoints)
+        return endpoints
+
+    async def _find_nearest_endpoints(self, endpoints: Sequence[str]) -> Optional[Iterator[Dict]]:
+        """select fastest endpoint with conditions below
+        1. Maximum block height (highest priority)
+        2. Minimum elapsed response time
+        3. target's state in ("Vote", "LeaderComplain", "Watch")
+
+        :param endpoints: list of endpoints information
+        :return: the fastest endpoint target "{scheme}://{netloc}"
+        """
+        results = await asyncio.gather(*[self._fetch_status(endpoint) for endpoint in endpoints],
+                                       return_exceptions=True)
+        results = [result for result in results if isinstance(result, dict)]  # to filter exceptions
+
+        if not results:
+            logging.warning(f"no alive node among endpoints({endpoints})")
+            return None
+
+        # sort results by min elapsed_time with max block height
+        sorted_result = sorted(results, key=lambda k: (-k['height'], k['elapsed_time']))
+        utils.logger.spam(f"nearest_endpoints: {sorted_result}, len({sorted_result})")
+        return cycle(sorted_result)
+
+    @staticmethod
+    def _normalize_target(min_latency_target):
+        normalized_target = utils.normalize_request_url(min_latency_target)
+        return f"{urlparse(normalized_target).scheme}://{urlparse(normalized_target).netloc}"
+
+    async def _fetch_status(self, endpoint: str) -> Optional[Dict]:
+        start_time = time.time()
+        response = await self._rest_client.call_async(endpoint, RestMethod.Status, conf.REST_TIMEOUT)
+        if response.get('state') not in ("Vote", "LeaderComplain", "Watch"):
+            return None
+
+        return {
+            'target': endpoint,
+            'elapsed_time': time.time() - start_time,
+            'height': response['block_height']
+        }

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -188,7 +188,8 @@ class NodeSubscriber:
                 self._exception = AnnounceNewBlockError(f"error: {type(e)}, message: {str(e)}")
             else:
                 logging.debug(f"add_confirmed_block height({confirmed_block.header.height}), "
-                              f"hash({confirmed_block.header.hash.hex()}), votes_dumped({votes_dumped})")
+                              f"hash({confirmed_block.header.hash.hex()}), votes_dumped({votes_dumped}), "
+                              f"from({self._target_uri})")
                 ObjectManager().channel_service.block_manager.add_confirmed_block(confirmed_block=confirmed_block,
                                                                                   confirm_info=vote)
             finally:

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -118,7 +118,7 @@ class NodeSubscriber:
             if self._exception:
                 raise self._exception
         except Exception as e:
-            logging.debug(f"Exception raised during handshake step: {e}", exc_info=True)
+            logging.debug(f"Exception raised during handshake step: {e}")
             await self.close()
             raise
         else:

--- a/loopchain/baseservice/rest_client.py
+++ b/loopchain/baseservice/rest_client.py
@@ -13,9 +13,6 @@
 # limitations under the License.
 """The Client Interface for REST call."""
 
-import asyncio
-import logging
-import time
 from collections import namedtuple
 from enum import Enum
 from typing import List, Optional, NamedTuple, Sequence, Iterator, Dict
@@ -48,95 +45,34 @@ class RestMethod(Enum):
 
 class RestClient:
     def __init__(self, channel=None):
-        self._target: str = None
-        self._latest_targets: Iterator[Dict] = None
         self._channel_name = channel or conf.LOOPCHAIN_DEFAULT_CHANNEL
 
-    async def init(self, endpoints: List[str]):
-        self._latest_targets = await self._select_fastest_endpoints(endpoints)
-        if self._latest_targets:
-            min_latency_target = next(self._latest_targets)['target']  # get first target
-            self._set_target(min_latency_target)
-
-    def init_next_target(self):
-        logging.debug(f"switching target from: {self._target}")
-        if not self._latest_targets:
-            return
-        next_target = next(self._latest_targets)['target']
-        logging.debug(f"switching target to: {next_target}")
-        self._set_target(next_target)
-
-    def _set_target(self, target):
-        self._target = self._normalize_target(target)
-        logging.info(f"RestClient init target({self._target})")
-
-    @staticmethod
-    def _normalize_target(min_latency_target):
-        normalized_target = utils.normalize_request_url(min_latency_target)
-        return f"{urlparse(normalized_target).scheme}://{urlparse(normalized_target).netloc}"
-
-    @property
-    def target(self):
-        return self._target
-
-    async def _fetch_status(self, endpoint: str):
-        start_time = time.time()
-        response = await self._call_async_rest(endpoint, RestMethod.Status, conf.REST_TIMEOUT)
-
-        return {
-            'target': endpoint,
-            'elapsed_time': time.time() - start_time,
-            'height': response['block_height']
-        }
-
-    async def _select_fastest_endpoints(self, endpoints: Sequence[str]) -> Optional[Iterator[Dict]]:
-        """select fastest endpoint with conditions below
-        1. Maximum block height (higher priority)
-        2. Minimum elapsed response time
-
-        :param endpoints: list of endpoints
-        :return: the fastest endpoint target "{scheme}://{netloc}"
-        """
-        results = await asyncio.gather(*[self._fetch_status(endpoint) for endpoint in endpoints],
-                                       return_exceptions=True)
-        results = [result for result in results if isinstance(result, dict)]  # to filter exceptions
-
-        if not results:
-            logging.warning(f"no alive node among endpoints({endpoints})")
-            return None
-
-        # sort results by min elapsed_time with max block height
-        sorted_result = sorted(results, key=lambda k: (-k['height'], k['elapsed_time']))
-        return iter(sorted_result)
-
-    def call(self, method: RestMethod, params: Optional[NamedTuple] = None, timeout=None) -> dict:
+    def call(self, uri, method: RestMethod, params: Optional[NamedTuple] = None, timeout=None) -> dict:
         timeout = timeout or conf.REST_ADDITIONAL_TIMEOUT
 
         try:
             if method.value.version == conf.ApiVersion.v1:
-                response = self._call_rest(self.target, method, timeout)
+                response = self._call_rest(uri, method, timeout)
             else:
-                response = self._call_jsonrpc(self.target, method, params, timeout)
+                response = self._call_jsonrpc(uri, method, params, timeout)
         except Exception as e:
-            logging.warning(f"REST call fail method_name({method.value.name}), caused by : {type(e)}, {e}")
             raise
         else:
             utils.logger.spam(f"REST call complete method_name({method.value.name})")
             return response
 
-    async def call_async(self, method: RestMethod, params: Optional[NamedTuple] = None, timeout=None) -> dict:
+    async def call_async(self, uri, method: RestMethod, params: Optional[NamedTuple] = None, timeout=None) -> dict:
         timeout = timeout or conf.REST_ADDITIONAL_TIMEOUT
 
         try:
             if method.value.version == conf.ApiVersion.v1:
-                response = await self._call_async_rest(self.target, method, timeout)
+                response = await self._call_async_rest(uri, method, timeout)
             else:
-                response = await self._call_async_jsonrpc(self.target, method, params, timeout)
+                response = await self._call_async_jsonrpc(uri, method, params, timeout)
         except Exception as e:
-            logging.warning(f"REST call async fail method_name({method.value.name}), caused by : {type(e)}, {e}")
             raise
         else:
-            utils.logger.spam(f"REST call async complete method_name({method.value.name})")
+            utils.logger.spam(f"REST call async complete with uri({uri}) method_name({method.value.name})")
             return response
 
     def _call_rest(self, target: str, method: RestMethod, timeout):
@@ -212,7 +148,7 @@ class RestClient:
         # noinspection PyProtectedMember
         params = params._asdict() if params else None
         if params:
-            params = { k: v for k, v in params.items() if v is not None}
+            params = {k: v for k, v in params.items() if v is not None}
             if "from_" in params:
                 params["from"] = params.pop("from_")
 

--- a/loopchain/baseservice/rest_client.py
+++ b/loopchain/baseservice/rest_client.py
@@ -1,16 +1,3 @@
-# Copyright 2019 ICON Foundation
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """The Client Interface for REST call."""
 
 from collections import namedtuple

--- a/loopchain/baseservice/rest_client_proxy.py
+++ b/loopchain/baseservice/rest_client_proxy.py
@@ -15,7 +15,7 @@ class RestClientProxy:
         try:
             return self.rest_client.call(uri, method, params, timeout)
         except Exception:
-            self.node_pool.find_next()
+            self.node_pool.find()
             raise
 
     async def call_async(self, method: RestMethod, params: Optional[NamedTuple] = None, timeout=None) -> dict:
@@ -23,5 +23,5 @@ class RestClientProxy:
         try:
             return await self.rest_client.call_async(uri, method, params, timeout)
         except Exception:
-            self.node_pool.find_next()
+            self.node_pool.find()
             raise

--- a/loopchain/baseservice/rest_client_proxy.py
+++ b/loopchain/baseservice/rest_client_proxy.py
@@ -1,0 +1,27 @@
+"""A proxy class for REST call."""
+
+from typing import Optional, NamedTuple
+
+from loopchain.baseservice import RestClient, RestMethod, NodePool
+
+
+class RestClientProxy:
+    def __init__(self, channel):
+        self.node_pool = NodePool(channel)
+        self.rest_client = RestClient(channel)
+
+    def call(self, method: RestMethod, params: Optional[NamedTuple] = None, timeout=None) -> dict:
+        uri = self.node_pool.target
+        try:
+            return self.rest_client.call(uri, method, params, timeout)
+        except Exception:
+            self.node_pool.find_next()
+            raise
+
+    async def call_async(self, method: RestMethod, params: Optional[NamedTuple] = None, timeout=None) -> dict:
+        uri = self.node_pool.target
+        try:
+            return await self.rest_client.call_async(uri, method, params, timeout)
+        except Exception:
+            self.node_pool.find_next()
+            raise

--- a/loopchain/blockchain/peer_loader.py
+++ b/loopchain/blockchain/peer_loader.py
@@ -4,7 +4,7 @@ import os
 
 from loopchain import configure as conf
 from loopchain import utils
-from loopchain.baseservice import ObjectManager, RestMethod
+from loopchain.baseservice import ObjectManager, RestClientProxy, RestMethod
 from loopchain.blockchain.blocks import BlockProverType
 from loopchain.blockchain.blocks.v0_3 import BlockProver
 from loopchain.blockchain.types import ExternalAddress, Hash32
@@ -50,10 +50,10 @@ class PeerLoader:
 
     @staticmethod
     def _load_peers_from_rest_call():
-        rs_client = ObjectManager().channel_service.rs_client
+        rest_client = RestClientProxy(ChannelProperty().name)
         crep_root_hash = conf.CHANNEL_OPTION[ChannelProperty().name].get('crep_root_hash')
-        reps = rs_client.call(
-            RestMethod.GetReps,
-            RestMethod.GetReps.value.params(crep_root_hash)
+        reps = rest_client.call(
+            method=RestMethod.GetReps,
+            params=RestMethod.GetReps.value.params(crep_root_hash)
         )
         return [{"id": rep["address"], "p2pEndpoint": rep["p2pEndpoint"]} for rep in reps]

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -408,7 +408,7 @@ class ChannelService:
         await subscribe_event.wait()
 
     def shutdown_peer(self, **kwargs):
-        logging.debug(f"channel_service:shutdown_peer")
+        logging.debug(f"shutdown_peer")
         StubCollection().peer_stub.sync_task().stop(message=kwargs['message'])
 
     def set_peer_type(self, peer_type):

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -386,7 +386,7 @@ class ChannelService:
                 return
 
             if exc:
-                self.__node_pool.find_next()
+                self.__node_pool.find()
                 if (self.__state_machine.state != "SubscribeNetwork"
                         or isinstance(exc, UnregisteredException)):
                     self.__state_machine.subscribe_network()

--- a/loopchain/configure_default.py
+++ b/loopchain/configure_default.py
@@ -179,9 +179,6 @@ class SendTxType(IntEnum):
     genesis_block = 3
 
 
-RUN_ICON_IN_LAUNCHER = False
-
-
 ##################
 # REST SERVICE ###
 ##################
@@ -270,7 +267,6 @@ CHANNEL_MANAGE_DATA_PATH = os.path.join(LOOPCHAIN_ROOT_PATH, 'channel_manage_dat
 ENABLE_CHANNEL_AUTH = True  # if this option is true, peer only gets channel infos to which it belongs.
 CHANNEL_RESTART_TIMEOUT = 120
 CHANNEL_BUILTIN = True
-
 
 ########
 # MQ ###
@@ -371,6 +367,7 @@ ALLOW_MAKE_EMPTY_BLOCK = True
 ####################
 # ICON ####
 ####################
+RUN_ICON_IN_LAUNCHER = False
 URL_CITIZEN_TESTNET = 'https://test-ctz.solidwallet.io'
 URL_CITIZEN_MAINNET = 'https://ctz.solidwallet.io'
 CONF_PATH_LOOPCHAIN_TESTNET = os.path.join(LOOPCHAIN_ROOT_PATH, 'conf/testnet/loopchain_conf.json')

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -11,7 +11,7 @@ from pkg_resources import parse_version
 
 import loopchain.utils as util
 from loopchain import configure as conf
-from loopchain.baseservice import TimerService, ObjectManager, Timer, RestMethod
+from loopchain.baseservice import TimerService, ObjectManager, Timer, RestMethod, RestClientProxy
 from loopchain.baseservice.aging_cache import AgingCache
 from loopchain.blockchain import (BlockChain, CandidateBlocks, Epoch, BlockchainError, NID, exception,
                                   NoConfirmInfo,
@@ -67,6 +67,7 @@ class BlockManager:
         self.__precommit_block: Block = None
         self.set_peer_type(loopchain_pb2.PEER)
         self.__service_status = status_code.Service.online
+        self._rest_client = RestClientProxy(self.__channel_name)
 
         # old_block_hashes[height][new_block_hash] = old_block_hash
         self.__old_block_hashes: DefaultDict[int, Dict[Hash32, Hash32]] = defaultdict(dict)
@@ -198,10 +199,6 @@ class BlockManager:
         return len(self.__txQueue)
 
     async def relay_all_txs(self):
-        rs_client = ObjectManager().channel_service.rs_client
-        if not rs_client:
-            return
-
         items = list(self.__txQueue.d.values())
         self.__txQueue.d.clear()
 
@@ -222,8 +219,10 @@ class BlockManager:
             raw_data["from_"] = raw_data.pop("from")
             for i in range(conf.RELAY_RETRY_TIMES):
                 try:
-                    await rs_client.call_async(rest_method,
-                                               rest_method.value.params(**raw_data))
+                    await self._rest_client.call_async(
+                        method=rest_method,
+                        params=rest_method.value.params(**raw_data)
+                    )
                 except Exception as e:
                     util.logger.warning(f"Relay failed. Tx({tx}), {e}")
                 else:
@@ -413,12 +412,11 @@ class BlockManager:
         return block, response.max_block_height, response.unconfirmed_block_height, votes, response.response_code
 
     def __block_request_by_citizen(self, block_height):
-        rs_client = ObjectManager().channel_service.rs_client
-        get_block_result = rs_client.call(
-            RestMethod.GetBlockByHeight,
-            RestMethod.GetBlockByHeight.value.params(height=str(block_height))
+        get_block_result = self._rest_client.call(
+            method=RestMethod.GetBlockByHeight,
+            params=RestMethod.GetBlockByHeight.value.params(height=str(block_height))
         )
-        last_block = rs_client.call(RestMethod.GetLastBlock)
+        last_block = self._rest_client.call(method=RestMethod.GetLastBlock)
         if not last_block:
             raise exception.InvalidBlockSyncTarget("The Radiostation may not be ready. It will retry after a while.")
 
@@ -712,10 +710,9 @@ class BlockManager:
         peer_stubs = []     # peer stub list for block height synchronization
 
         if not ObjectManager().channel_service.is_support_node_function(conf.NodeFunction.Vote):
-            rs_client = ObjectManager().channel_service.rs_client
-            status_response = rs_client.call(RestMethod.Status)
+            status_response = self._rest_client.call(method=RestMethod.Status)
             max_height = status_response['block_height']
-            peer_stubs.append((rs_client.target, rs_client))
+            peer_stubs.append((self._rest_client.node_pool.target, self._rest_client))
             return max_height, unconfirmed_block_height, peer_stubs
 
         # Make Peer Stub List [peer_stub, ...] and get max_height of network

--- a/loopchain/peer/status_code.py
+++ b/loopchain/peer/status_code.py
@@ -15,7 +15,7 @@
 
 from enum import IntEnum
 
-import loopchain_pb2
+from loopchain.protos import loopchain_pb2
 
 
 class Service(IntEnum):

--- a/testcase/unittest/baseservice/test_node_pool.py
+++ b/testcase/unittest/baseservice/test_node_pool.py
@@ -1,0 +1,119 @@
+import time
+
+import pytest
+
+from loopchain import configure as conf
+from loopchain.baseservice.node_pool import NodePool
+from collections import namedtuple
+
+
+FetchedStatus = namedtuple("Status", "target, elapsed_time, height")
+
+
+class TestNodePool:
+    CHANNEL_NAME = "icon_dex"
+    TEST_STATUS = [
+        FetchedStatus(target="127.0.0.1:0", elapsed_time=0.01, height=5),
+        FetchedStatus(target="127.0.0.1:1", elapsed_time=0.02, height=4),
+        FetchedStatus(target="127.0.0.1:2", elapsed_time=0.03, height=3),
+        FetchedStatus(target="127.0.0.1:3", elapsed_time=0.04, height=2),
+        FetchedStatus(target="127.0.0.1:4", elapsed_time=0.05, height=1),
+    ]
+
+    def get_status_by_endpoint(self, endpoint) -> FetchedStatus:
+        """Helper for getting status data matched to given endpoint."""
+        return next(status for status in self.TEST_STATUS if status.target == endpoint)
+
+    @pytest.fixture
+    def node_pool(self, mocker):
+        channel_option = {
+            self.CHANNEL_NAME: {
+                "radiostations": [status.target for status in self.TEST_STATUS]
+            }
+        }
+        mocker.patch.object(conf, "CHANNEL_OPTION", channel_option)
+        node_pool = NodePool(self.CHANNEL_NAME)
+
+        return node_pool
+
+    def test_init_without_rs(self):
+        with pytest.raises(RuntimeError, match="radiostations"):
+            NodePool(self.CHANNEL_NAME)
+
+    @pytest.mark.skip(reason="Slow")
+    def test_concurrent_in_find_nearst(self, node_pool):
+        def _mock_fetch_status(endpoint: str):
+            port = int(endpoint.split(":")[-1])
+            start_time = time.time()
+            time.sleep(port)
+
+            result = {
+                'target': endpoint,
+                'elapsed_time': time.time() - start_time,
+                'height': port
+            }
+
+            return result
+
+        node_pool._fetch_status = _mock_fetch_status
+        node_pool.find()
+
+    def test_fastest_is_nearest_target(self, node_pool):
+        def _mock_fetch_status(endpoint: str):
+            status: FetchedStatus = self.get_status_by_endpoint(endpoint)
+            return {
+                'target': status.target,
+                'elapsed_time': status.elapsed_time,
+                'height': status.height
+            }
+
+        node_pool._fetch_status = _mock_fetch_status
+        node_pool.find()
+
+        assert node_pool.target == f"http://{self.TEST_STATUS[0].target}"
+
+    def test_remove_current_target_after_find(self, node_pool):
+        def _mock_fetch_status(endpoint: str):
+            status: FetchedStatus = self.get_status_by_endpoint(endpoint)
+            return {
+                'target': status.target,
+                'elapsed_time': status.elapsed_time,
+                'height': status.height
+            }
+
+        node_pool._fetch_status = _mock_fetch_status
+        node_pool.find()
+        assert node_pool.target == f"http://{self.TEST_STATUS[0].target}"
+
+        node_pool.find()
+        assert node_pool.target == f"http://{self.TEST_STATUS[1].target}"
+
+    @pytest.mark.parametrize("available_state", ["Vote", "LeaderComplain", "Watch"])
+    def test_nodes_must_in_available_states(self, node_pool, available_state):
+        def _mock_call(endpoint, status, timeout):
+            original_data: FetchedStatus = self.get_status_by_endpoint(endpoint)
+
+            return {
+                "state": available_state,
+                "block_height": original_data.height
+            }
+
+        node_pool._rest_client.call = _mock_call
+        node_pool.find()
+
+        assert node_pool.target in (f"http://{status.target}" for status in self.TEST_STATUS)
+
+    @pytest.mark.parametrize("ignored_state", ["BlockGenerate", "SubscribeNetwork"])
+    def test_nodes_ignored_if_not_in_available_states(self, node_pool, ignored_state):
+        def _mock_call(endpoint, status, timeout):
+            original_data: FetchedStatus = self.get_status_by_endpoint(endpoint)
+
+            return {
+                "state": ignored_state,
+                "block_height": original_data.height
+            }
+
+        node_pool._rest_client.call = _mock_call
+        node_pool.find()
+
+        assert not node_pool.target


### PR DESCRIPTION
**[should be merged after LC-791(#440) is merged]**

- separate `NodePool` and add `RestClientProxy` from `RestClient` that manages nearest node endpoints

