### PR TITLE
[LC-834] show version of loopchain and it's dependencies

### DIFF
--- a/loopchain/configure.py
+++ b/loopchain/configure.py
@@ -143,16 +143,20 @@ class Configure(metaclass=SingletonMetaClass):
                 self.__change_enum_to_int(value)
 
     def _set_package_version(self):
-        installed_pkg = [package.project_name for package in pkg_resources.working_set]
-        filtered_pkg = [pkg for pkg in installed_pkg if pkg in globals()['ICON_VERSIONS'].keys()]
-        for package in filtered_pkg:
-            version = pkg_resources.get_distribution(package).version
-            globals()['ICON_VERSIONS'][package] = version
+        icon_versions: dict = globals()['ICON_VERSIONS']
+        for pkg_name in icon_versions.keys() - {'icon_rc'}:
+            try:
+                version = pkg_resources.get_distribution(pkg_name).version
+                icon_versions[pkg_name] = version
+            except pkg_resources.DistributionNotFound as e:
+                logging.warning(f"get '{pkg_name}' version error : {e}")
+                continue
+
         command_result = os.popen('icon_rc -version').read()
         match_result = re.match(r'([a-z_]+)\s([\da-zA-Z-_\.]+)', command_result)  # ('icon_rc', 'vX.X.X')
         if match_result:
             icon_rc_version = match_result.group(2)
-            globals()['ICON_VERSIONS']['icon_rc'] = icon_rc_version
+            icon_versions['icon_rc'] = icon_rc_version
 
 
 def get_configuration(configure_name):

--- a/loopchain/launcher.py
+++ b/loopchain/launcher.py
@@ -19,7 +19,6 @@ import json
 import logging
 import os
 import time
-from urllib.parse import urlparse, ParseResult
 
 from loopchain import configure as conf
 from loopchain import utils
@@ -57,6 +56,10 @@ def main(argv):
 
     args, unknowns = parse_args_include_unknowns(parser, argv)
     quick_command = get_quick_command(unknowns)
+
+    if args.version:
+        print(json.dumps(conf.ICON_VERSIONS, indent=2))
+        parser.exit()
 
     command_arguments.set_raw_commands(args)
 
@@ -97,7 +100,7 @@ def main(argv):
         start_as_admin(args, quick_command)
     else:
         print(f"not supported service type {args.service_type}\ncheck loopchain help.\n")
-        os.system("python3 ./loopchain.py -h")
+        parser.print_help()
 
 
 def check_port_available(port):

--- a/loopchain/utils/command_arguments/__init__.py
+++ b/loopchain/utils/command_arguments/__init__.py
@@ -29,6 +29,7 @@ class Type(IntEnum):
     Channel = 8
     AMQPTarget = 9
     AMQPKey = 10
+    Version = 11
 
 
 class Attribute:
@@ -60,7 +61,8 @@ types_by_names = {
     "seed": Type.Seed,
     "channel": Type.Channel,
     "amqp_target": Type.AMQPTarget,
-    "amqp_key": Type.AMQPKey
+    "amqp_key": Type.AMQPKey,
+    "version": Type.Version
 }
 
 attributes = {
@@ -111,8 +113,11 @@ attributes = {
 
     Type.AMQPKey:
         Attribute("--amqp_key",
-                  help="key sharing peer group using queue name. use it if one more peers connect one MQ")
+                  help="key sharing peer group using queue name. use it if one more peers connect one MQ"),
 
+    Type.Version:
+        Attribute("--version", action='store_true',
+                  help="show version of loopchain and it's dependencies")
 }
 
 command_values: Dict[Type, str] = {}


### PR DESCRIPTION
 - to see versions, type `loop --version`
 - update some inefficient codes

versions example.
```json
{
  "loopchain": "2.4.20",
  "iconservice": "1.5.18",
  "iconrpcserver": "1.4.9",
  "iconcommons": "1.1.2",
  "earlgrey": "0.0.4",
  "icon_rc": "v1.1.2"
}
```