### PR TITLE
[LC-806] Add logic to reset network.

### DIFF
--- a/loopchain/baseservice/rest_client.py
+++ b/loopchain/baseservice/rest_client.py
@@ -59,16 +59,16 @@ class RestClient:
             self._set_target(min_latency_target)
 
     def init_next_target(self):
-        logging.debug(f"switching target from: {self._target}")
+        utils.logger.debug(f"switching target from: {self._target}")
         if not self._latest_targets:
             return
         next_target = next(self._latest_targets)['target']
-        logging.debug(f"switching target to: {next_target}")
+        utils.logger.debug(f"switching target to: {next_target}")
         self._set_target(next_target)
 
     def _set_target(self, target):
         self._target = self._normalize_target(target)
-        logging.info(f"RestClient init target({self._target})")
+        utils.logger.info(f"RestClient init target({self._target})")
 
     @staticmethod
     def _normalize_target(min_latency_target):
@@ -102,7 +102,7 @@ class RestClient:
         results = [result for result in results if isinstance(result, dict)]  # to filter exceptions
 
         if not results:
-            logging.warning(f"no alive node among endpoints({endpoints})")
+            utils.logger.warning(f"no alive node among endpoints({endpoints})")
             return None
 
         # sort results by min elapsed_time with max block height
@@ -118,7 +118,7 @@ class RestClient:
             else:
                 response = self._call_jsonrpc(self.target, method, params, timeout)
         except Exception as e:
-            logging.warning(f"REST call fail method_name({method.value.name}), caused by : {type(e)}, {e}")
+            utils.logger.warning(f"REST call fail method_name({method.value.name}), caused by : {type(e)}, {e}")
             raise
         else:
             utils.logger.spam(f"REST call complete method_name({method.value.name})")
@@ -133,7 +133,7 @@ class RestClient:
             else:
                 response = await self._call_async_jsonrpc(self.target, method, params, timeout)
         except Exception as e:
-            logging.warning(f"REST call async fail method_name({method.value.name}), caused by : {type(e)}, {e}")
+            utils.logger.warning(f"REST call async fail method_name({method.value.name}), caused by : {type(e)}, {e}")
             raise
         else:
             utils.logger.spam(f"REST call async complete method_name({method.value.name})")

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -835,7 +835,7 @@ class BlockChain:
             self.__nid = nid.decode(conf.HASH_KEY_ENCODING)
             return self.__nid
         except KeyError as e:
-            logging.debug(f"blockchain:get_nid::There is no NID.")
+            logging.debug(f"There is no NID.")
             return None
 
     def add_tx_to_list_by_address(self, address, tx_hash, batch=None):

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -512,6 +512,16 @@ class ChannelInnerTask:
             return json.dumps(bs.serialize(new_block)), confirm_info
 
     @message_queue_task
+    def try_block_sync(self, subscriber_block_height: int):
+        node_type = ChannelProperty().node_type.value
+        state_machine = self._channel_service.state_machine
+        if node_type == conf.NodeType.CommunityNode:
+            if state_machine.state == 'LeaderComplain':
+                state_machine.reset_network()
+            elif subscriber_block_height > self._blockchain.block_height + 2:
+                state_machine.block_sync()
+
+    @message_queue_task
     async def register_citizen(self, peer_id, target, connected_time):
         register_condition = (len(self._citizens) < conf.SUBSCRIBE_LIMIT
                               and (peer_id not in self._citizens)

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -62,10 +62,12 @@ class ChannelStateMachine(object):
         self.__channel_service = channel_service
 
         self.machine.add_transition(
-            'complete_subscribe', 'SubscribeNetwork', 'BlockGenerate', conditions=['_is_leader'])
+            'complete_subscribe', 'SubscribeNetwork', 'BlockGenerate', conditions='_is_leader')
         self.machine.add_transition(
-            'complete_subscribe', 'SubscribeNetwork', 'Watch', conditions=['_has_no_vote_function'])
+            'complete_subscribe', 'SubscribeNetwork', 'Watch', conditions='_has_no_vote_function')
         self.machine.add_transition('complete_subscribe', 'SubscribeNetwork', 'Vote')
+        self.machine.add_transition(
+            'reset_network', 'LeaderComplain', 'ResetNetwork', unless='_has_no_vote_function')
 
     @statemachine.transition(source='InitComponents', dest='Consensus')
     def complete_init_components(self):
@@ -97,6 +99,9 @@ class ChannelStateMachine(object):
         pass
 
     def complete_subscribe(self):
+        pass
+
+    def reset_network(self):
         pass
 
     @statemachine.transition(source='BlockSync', dest='SubscribeNetwork')

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -755,7 +755,8 @@ class BlockManager:
                 continue
             if target in self.__block_height_sync_bad_targets:
                 continue
-            util.logger.debug(f"try to target({target})")
+
+            util.logger.info(f"try to connect to {target}.")
             channel = GRPCHelper().create_client_channel(target)
             stub = loopchain_pb2_grpc.PeerServiceStub(channel)
             try:

--- a/testcase/unittest/test_vote.py
+++ b/testcase/unittest/test_vote.py
@@ -278,8 +278,6 @@ class TestVote(unittest.TestCase):
             leader_votes.add_vote(leader_vote)
 
         leader_votes.get_summary()
-        print(f"leader_votes.is_completed(): {leader_votes.is_completed()}")
-        print(f"leader_votes.get_result(): {leader_votes.get_result()}")
         self.assertEqual(leader_votes.is_completed(), False)
         self.assertEqual(leader_votes.get_result(), None)
 
@@ -288,8 +286,6 @@ class TestVote(unittest.TestCase):
             leader_votes.add_vote(leader_vote)
 
         leader_votes.get_summary()
-        print(f"leader_votes.is_completed(): {leader_votes.is_completed()}")
-        print(f"leader_votes.get_result(): {leader_votes.get_result()}")
         self.assertEqual(leader_votes.is_completed(), True)
         self.assertEqual(leader_votes.get_result(), next_leader)
 


### PR DESCRIPTION
(coupled: https://github.com/icon-project/icon-rpc-server/pull/124)

Add logic to reset network when a node gets a request that wants to send a block from a subscriber that has a higher height than it.
- Add a transition `reset_network` in the `state machine` of the channel.
- Replace `logging` to `utils.logger`.
- Edit some logs.
- Remove unnecessary logs.