### PR TITLE
[LC-847] Edit condition to select the block in DB if it is not in  candidate blocks.

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -385,8 +385,8 @@ class BlockChain:
         try:
             prev_block = candidate_blocks.blocks[prev_hash].block
             if not prev_block:
-                raise KeyError
-        except KeyError:
+                raise BlockNotExist
+        except (BlockNotExist, KeyError):
             utils.logger.spam(f"prev_block is not in candidate_blocks by prev_hash({prev_hash})")
             prev_block = self.find_block_by_hash32(prev_hash) or self.last_block
 

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -384,9 +384,10 @@ class BlockChain:
 
         try:
             prev_block = candidate_blocks.blocks[prev_hash].block
-            utils.logger.spam(
-                f"prev_block is None.({prev_block is None}) in candidate_blocks by prev_hash({prev_hash})")
+            if not prev_block:
+                raise KeyError
         except KeyError:
+            utils.logger.spam(f"prev_block is not in candidate_blocks by prev_hash({prev_hash})")
             prev_block = self.find_block_by_hash32(prev_hash) or self.last_block
 
         return prev_block

--- a/loopchain/blockchain/exception.py
+++ b/loopchain/blockchain/exception.py
@@ -123,6 +123,12 @@ class NoConfirmInfo(Exception):
     pass
 
 
+class BlockNotExist(Exception):
+    """
+    """
+    pass
+
+
 class AnnounceNewBlockError(Exception):
     """When AnnounceNewBlockError is raised during Watch state,
     this node would transit the state to BlockSync.


### PR DESCRIPTION
The `KeyError` exception is possibly not raised in the `get_prev_block` method because of the `CandidateBlocks` is changed. `CandidateBlock` object is created again if a vote arrived even though its target has been processed already. That's why the condition is added to treat the same with the case that `KeyError` exception if a previous block is None.