### PR TITLE
[LC-861] Additional logs to NodeSubscriber

### DIFF
--- a/testcase/unittest/baseservice/test_node_subscriber.py
+++ b/testcase/unittest/baseservice/test_node_subscriber.py
@@ -35,6 +35,10 @@ def mock_ws(mocker):
             self.mock_close = mocker_fixture.MagicMock()
 
         @property
+        def remote_address(self):
+            return "remote_address"
+
+        @property
         def closed(self) -> bool:
             """Fake status for websocket connection.
 


### PR DESCRIPTION
(coupled: https://github.com/icon-project/icon-rpc-server/pull/126)

# Goals
- Add necessary logs in Citizen related files.
  - Currently no useful information logged about connection between citizen and its parent.