### PR TITLE
[LC-867] Fix initialization logic of `RestClient`

### DIFF
--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -196,10 +196,9 @@ class ChannelService:
         await self.__inner_service.connect(conf.AMQP_CONNECTION_ATTEMPTS, conf.AMQP_RETRY_DELAY, exclusive=True)
         await self.__init_sub_services()
 
-        self.__block_manager.blockchain.init_crep_reps()
-
     async def evaluate_network(self):
         await self._init_rs_client()
+        self.__block_manager.blockchain.init_crep_reps()
         await self._select_node_type()
         self.__ready_to_height_sync()
         self.__state_machine.block_sync()


### PR DESCRIPTION
# Problem
- `RestClient` Initialize failure when node starts.
```
Traceback (most recent call last):
  File "/Users/jsj8830/projects/loopchain/loopchain/channel/channel_service.py", line 120, in _serve
    await self.init(**results)
  File "/Users/jsj8830/projects/loopchain/loopchain/channel/channel_service.py", line 201, in init
    self.__block_manager.blockchain.init_crep_reps()
  File "/Users/jsj8830/projects/loopchain/loopchain/blockchain/blockchain.py", line 1095, in init_crep_reps
    reps_hash, reps = PeerLoader.load()
  File "/Users/jsj8830/projects/loopchain/loopchain/blockchain/peer_loader.py", line 28, in load
    peers = PeerLoader._load_peers_from_rest_call()
  File "/Users/jsj8830/projects/loopchain/loopchain/blockchain/peer_loader.py", line 55, in _load_peers_from_rest_call
    reps = rs_client.call(
AttributeError: 'NoneType' object has no attribute 'call'
```

# Origin of problem
- Node asks reps data from others through REST call, when there is no initial reps data. 
  - This happens when `ChannelService.__init__`
- `RestClient` which is responsible for REST call is initialized AFTER ChannelService initialized.
