### PR TITLE
[LC-862] Change BLOCK_MONITORING TIMER logic

### DIFF
--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -162,6 +162,8 @@ class NodeSubscriber:
             await self.close()
 
     async def node_ws_PublishNewBlock(self, **kwargs):
+        ObjectManager().channel_service.remove_block_monitoring_timer()
+
         block_dict, votes_dumped = kwargs.get('block'), kwargs.get('confirm_info', '')
         try:
             votes_serialized = json.loads(votes_dumped)
@@ -193,7 +195,7 @@ class NodeSubscriber:
                 ObjectManager().channel_service.block_manager.add_confirmed_block(confirmed_block=confirmed_block,
                                                                                   confirm_info=vote)
             finally:
-                ObjectManager().channel_service.reset_block_monitoring_timer()
+                ObjectManager().channel_service.start_block_monitoring_timer()
 
     async def node_ws_PublishHeartbeat(self, **kwargs):
         def _callback(exception):

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -608,16 +608,17 @@ class ChannelService:
         self.__timer_service.stop_timer(TimerService.TIMER_KEY_SHUTDOWN_WHEN_FAIL_SUBSCRIBE)
 
     def start_block_monitoring_timer(self):
-        self.__timer_service.add_timer_convenient(timer_key=TimerService.TIMER_KEY_BLOCK_MONITOR,
-                                                  duration=conf.TIMEOUT_FOR_BLOCK_MONITOR,
-                                                  callback=self.state_machine.subscribe_network)
-
-    def reset_block_monitoring_timer(self):
-        if self.__timer_service.get_timer(TimerService.TIMER_KEY_BLOCK_MONITOR):
-            self.__timer_service.reset_timer(TimerService.TIMER_KEY_BLOCK_MONITOR)
+        if not self.__timer_service.get_timer(TimerService.TIMER_KEY_BLOCK_MONITOR):
+            self.__timer_service.add_timer_convenient(timer_key=TimerService.TIMER_KEY_BLOCK_MONITOR,
+                                                      duration=conf.TIMEOUT_FOR_BLOCK_MONITOR,
+                                                      callback=self.state_machine.subscribe_network)
 
     def stop_block_monitoring_timer(self):
         self.__timer_service.stop_timer(TimerService.TIMER_KEY_BLOCK_MONITOR)
+
+    def remove_block_monitoring_timer(self):
+        if self.__timer_service.get_timer(TimerService.TIMER_KEY_BLOCK_MONITOR):
+            self.__timer_service.remove_timer(TimerService.TIMER_KEY_BLOCK_MONITOR)
 
     def stop_ws_heartbeat_timer(self):
         self.__timer_service.stop_timer(TimerService.TIMER_KEY_WS_HEARTBEAT)


### PR DESCRIPTION
# What is block_monitoring_timer
`BLOCK_MONITORING_TIMER` aims to re-subscribe parent node when the node does not receive any block from its parent within timeout secs (default 14 sec)

# Problem
Currently this timer may change state regardless of its origin goal if:
- block verification is delayed after received new block,
- writing block to db is delayed after verification,
> It means that all processes after receiving block must be done within timeout-sec, to reset the timer.

# Goal
- Remove the timer when the node receives block.
- Add the timer when the node finishes its writing job.