### PR TITLE
[LC-897] Version up jsonrpcserver (3.5.6 -> 4.1.2)

### DIFF
--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -22,7 +22,6 @@ from urllib import parse
 import websockets
 from earlgrey import MessageQueueService
 from jsonrpcclient.requests import Request
-from jsonrpcserver import config
 from jsonrpcserver.aio import AsyncMethods
 from websockets import WebSocketClientProtocol
 
@@ -35,8 +34,6 @@ from loopchain.blockchain.votes import Votes
 from loopchain.channel.channel_property import ChannelProperty
 from loopchain.protos import message_code
 
-config.log_requests = False
-config.log_responses = False
 ws_methods = AsyncMethods()
 CONNECTION_FAIL_CONDITIONS = {
     message_code.Response.fail_subscribe_limit,

--- a/loopchain/baseservice/node_subscriber.py
+++ b/loopchain/baseservice/node_subscriber.py
@@ -22,7 +22,8 @@ from urllib import parse
 import websockets
 from earlgrey import MessageQueueService
 from jsonrpcclient.requests import Request
-from jsonrpcserver.aio import AsyncMethods
+from jsonrpcserver import async_dispatch
+from jsonrpcserver.methods import Methods
 from websockets import WebSocketClientProtocol
 
 from loopchain import configure as conf
@@ -34,7 +35,7 @@ from loopchain.blockchain.votes import Votes
 from loopchain.channel.channel_property import ChannelProperty
 from loopchain.protos import message_code
 
-ws_methods = AsyncMethods()
+ws_methods = Methods()
 CONNECTION_FAIL_CONDITIONS = {
     message_code.Response.fail_subscribe_limit,
     message_code.Response.fail_connection_closed,
@@ -50,11 +51,12 @@ class UnregisteredException(Exception):
     pass
 
 
-def convert_response_to_dict(response: bytes) -> dict:
-    response_dict: dict = json.loads(response)
-    response_dict = _check_error_in_response(response_dict)
+def validate_response(response: str) -> str:
+    res: dict = json.loads(response)
+    res = _check_error_in_response(res)
+    res: str = json.dumps(res)
 
-    return response_dict
+    return res
 
 
 def _check_error_in_response(response_dict: dict) -> dict:
@@ -132,13 +134,13 @@ class NodeSubscriber:
         await self._websocket.send(json.dumps(request))
 
     async def _recv_until_timeout(self):
-        response: bytes = await asyncio.wait_for(
+        response: str = await asyncio.wait_for(
             fut=self._websocket.recv(),
             timeout=2 * conf.TIMEOUT_FOR_WS_HEARTBEAT
         )
-        response_dict = convert_response_to_dict(response)
+        response = validate_response(response)
 
-        await ws_methods.dispatch(response_dict)
+        await async_dispatch(response, ws_methods)
 
     async def _run(self):
         try:

--- a/loopchain/jsonrpc/exception.py
+++ b/loopchain/jsonrpc/exception.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from jsonrpcserver.exceptions import JsonRpcServerError
+from jsonrpcserver.exceptions import ApiError
 
 
 class JsonError:
@@ -25,7 +25,7 @@ class JsonError:
     SCORE_ERROR = -32100
 
 
-class GenericJsonRpcServerError(JsonRpcServerError):
+class GenericJsonRpcServerError(ApiError):
     """Raised when the request is not a valid JSON-RPC object.
     User can change code and message properly
 
@@ -40,8 +40,5 @@ class GenericJsonRpcServerError(JsonRpcServerError):
         :param http_status: http status code
         :param data: json-rpc error data (optional)
         """
-        super().__init__(data)
-
-        self.code = code
-        self.message = message
-        self.http_status = http_status
+        # FIXME: Replace GenericJsonRpcServerError as ApiError itself
+        super().__init__(message=message, code=code, data=data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ coloredlogs==10.0
 earlgrey>=0.0.4
 fluent-logger==0.9.3
 jsonrpcclient==3.3.5
-jsonrpcserver==3.5.6
+jsonrpcserver==4.1.2
 leveldb==0.20
 plyvel>=1.0.5
 pika==0.12.0


### PR DESCRIPTION
(coupled: https://github.com/icon-project/icon-rpc-server/pull/131)

# Changes
- `GenericJsonRpcServerError` now inherits `jsonrpcserver.exceptions.ApiError` (`JsonRpcServerError` deprecated in `jsonrpcserver`)
- `jsonrpcserver.config` is no more used (also deprecated in `jsonrpcserver`).
- Change dispatcher param type. It needs dumped string, not a dict itself.
- Add dispatched methods to `jsonrpcserver.methods.Methods`, not to `AsyncMethods` (`AsyncMethods` deprecated).