### PR TITLE
[LC-898] remove gunicorn dependency in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ aiohttp==3.4.4
 coloredlogs==10.0
 earlgrey>=0.0.4
 fluent-logger==0.9.3
-gunicorn==19.9.0
 jsonrpcclient==3.3.5
 jsonrpcserver==3.5.6
 leveldb==0.20


### PR DESCRIPTION
`guincorn` use by `iconrpcserver` only.

related PR : https://github.com/icon-project/icon-rpc-server/pull/132
