### PR TITLE
[LC-624] Remove `redirectProtocol` in configs

### DIFF
--- a/citizen/conf/iconrpcserver_mainnet.json
+++ b/citizen/conf/iconrpcserver_mainnet.json
@@ -19,6 +19,5 @@
     "amqpKey": "7100",
     "gunicornConfig": {
         "workers": 1
-    },
-    "redirectProtocol": "https"
+    }
 }

--- a/citizen/conf/iconrpcserver_testnet.json
+++ b/citizen/conf/iconrpcserver_testnet.json
@@ -19,6 +19,5 @@
     "amqpKey": "7100",
     "gunicornConfig": {
         "workers": 1
-    },
-    "redirectProtocol": "https"
+    }
 }

--- a/conf/mainnet/iconrpcserver_conf.json
+++ b/conf/mainnet/iconrpcserver_conf.json
@@ -13,7 +13,6 @@
             "maxBytes": 50000000
         }
     },
-    "redirectProtocol": "https",
     "gunicornConfig": {
         "workers": 1,
         "graceful_timeout": 0

--- a/conf/testnet/iconrpcserver_conf.json
+++ b/conf/testnet/iconrpcserver_conf.json
@@ -13,7 +13,6 @@
             "maxBytes": 50000000
         }
     },
-    "redirectProtocol": "https",
     "gunicornConfig": {
         "workers": 1,
         "graceful_timeout": 0


### PR DESCRIPTION
# Goal
- Remove `redirectProtocol` of `ICON-RPC-Server` in mainnet, testnet, citizen dist configs.
**_NOTE_**: Redirection URL (the url that txs are expected to be sent to, if the node is citizen) is supplied by `Loopchain`, and no more allowed for the option to be set in `ICON-RPC-Server`.

> caused: https://github.com/icon-project/icon-rpc-server/pull/105