### PR TITLE
[LC-947] Remove dependency: fluent-logger

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -578,16 +578,6 @@ class BlockChain:
                     not self.prevent_next_block_mismatch(block.header.height):
                 return True
 
-            peer_id = ChannelProperty().peer_id
-            utils.apm_event(peer_id, {
-                'event_type': 'TotalTx',
-                'peer_id': peer_id,
-                'peer_name': conf.PEER_NAME,
-                'channel_name': self.__channel_name,
-                'data': {
-                    'block_hash': block.header.hash.hex(),
-                    'total_tx': self.total_tx}})
-
             return self.__add_block(block, confirm_info, need_to_write_tx_info, need_to_score_invoke)
 
     def __add_block(self, block: Block, confirm_info, need_to_write_tx_info=True, need_to_score_invoke=True):
@@ -625,15 +615,6 @@ class BlockChain:
                 f"HASH : {block.header.hash.hex()} , "
                 f"CHANNEL : {self.__channel_name}")
             utils.logger.debug(f"ADDED BLOCK HEADER : {block.header}")
-
-            utils.apm_event(self.__peer_id, {
-                'event_type': 'AddBlock',
-                'peer_id': self.__peer_id,
-                'peer_name': conf.PEER_NAME,
-                'channel_name': self.__channel_name,
-                'data': {
-                    'block_height': self.__last_block.header.height
-                }})
 
             if not (conf.SAFE_BLOCK_BROADCAST and channel_service.state_machine.state == 'BlockGenerate'):
                 channel_service.inner_service.notify_new_block()

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -468,12 +468,6 @@ class ChannelInnerTask:
                 continue
 
             self._block_manager.add_tx_obj(tx)
-            util.apm_event(ChannelProperty().peer_id, {
-                'event_type': 'AddTx',
-                'peer_id': ChannelProperty().peer_id,
-                'peer_name': conf.PEER_NAME,
-                'channel_name': ChannelProperty().name,
-                'data': {'tx_hash': tx.hash.hex()}})
 
         if not conf.ALLOW_MAKE_EMPTY_BLOCK:
             self._channel_service.start_leader_complain_timer_if_tx_exists()
@@ -627,14 +621,6 @@ class ChannelInnerTask:
         except Exception as e:
             data_log = {'tx_hash': tx.tx_hash}
 
-        util.apm_event(ChannelProperty().peer_id, {
-            'event_type': 'CreateTx',
-            'peer_id': ChannelProperty().peer_id,
-            'peer_name': conf.PEER_NAME,
-            'channel_name': ChannelProperty().name,
-            'tx_hash': tx.tx_hash,
-            'data': data_log})
-
         return tx.tx_hash
 
     @message_queue_task(type_=MessageQueueType.Worker)
@@ -652,12 +638,6 @@ class ChannelInnerTask:
 
         if tx is not None:
             self._block_manager.add_tx_obj(tx)
-            util.apm_event(ChannelProperty().peer_id, {
-                'event_type': 'AddTx',
-                'peer_id': ChannelProperty().peer_id,
-                'peer_name': conf.PEER_NAME,
-                'channel_name': ChannelProperty().name,
-                'data': {'tx_hash': tx.tx_hash}})
 
         if not conf.ALLOW_MAKE_EMPTY_BLOCK:
             self._channel_service.start_leader_complain_timer_if_tx_exists()
@@ -796,13 +776,6 @@ class ChannelInnerTask:
             response_code = message_code.Response.success
             logging.debug('invoke_result : ' + invoke_result_str)
 
-            util.apm_event(ChannelProperty().peer_id, {
-                'event_type': 'GetInvokeResult',
-                'peer_id': ChannelProperty().peer_id,
-                'peer_name': conf.PEER_NAME,
-                'channel_name': ChannelProperty().name,
-                'data': {'invoke_result': invoke_result, 'tx_hash': tx_hash}})
-
             if 'code' in invoke_result:
                 if invoke_result['code'] == ScoreResponse.NOT_EXIST:
                     logging.debug(f"get invoke result NOT_EXIST tx_hash({tx_hash})")
@@ -814,15 +787,7 @@ class ChannelInnerTask:
             return response_code, invoke_result_str
         except BaseException as e:
             logging.error(f"get invoke result error : {e}")
-            util.apm_event(ChannelProperty().peer_id, {
-                'event_type': 'Error',
-                'peer_id': ChannelProperty().peer_id,
-                'peer_name': conf.PEER_NAME,
-                'channel_name': ChannelProperty().name,
-                'data': {
-                    'error_type': 'InvokeResultError',
-                    'code': message_code.Response.fail,
-                    'message': f"get invoke result error : {e}"}})
+
             return message_code.Response.fail, None
 
     @message_queue_task

--- a/loopchain/configure_default.py
+++ b/loopchain/configure_default.py
@@ -50,11 +50,6 @@ LOG_FILE_ROTATE_MAX_BYTES = 0  # Default 0, Do not rotate log files by max bytes
 LOG_FILE_ROTATE_BACKUP_COUNT = 10
 LOG_FILE_ROTATE_UTC = False
 
-MONITOR_LOG = False
-MONITOR_LOG_HOST = 'localhost'
-MONITOR_LOG_PORT = 24224
-MONITOR_LOG_MODULE = 'fluent'
-
 
 ###################
 # MULTI PROCESS ###

--- a/loopchain/utils/__init__.py
+++ b/loopchain/utils/__init__.py
@@ -21,26 +21,23 @@ import os
 import re
 import signal
 import socket
+import sys
+import time
 import timeit
 import traceback
+from binascii import unhexlify
 from contextlib import closing
 from decimal import Decimal
 from pathlib import Path
 from subprocess import PIPE, Popen, TimeoutExpired
 from typing import Tuple, Union
 
-import sys
-import time
 import verboselogs
-from binascii import unhexlify
-from fluent import event
 
 from loopchain import configure as conf
 from loopchain.protos import message_code
 from loopchain.store.key_value_store import KeyValueStoreError, KeyValueStore
 from loopchain.tools.grpc_helper import GRPCHelper
-
-apm_event = None
 
 logger = verboselogs.VerboseLogger("dev")
 
@@ -489,14 +486,6 @@ def init_default_key_value_store(store_identity) -> Tuple[KeyValueStore, str]:
     return store, store_path
 
 
-def no_send_apm_event(peer_id, event_param):
-    pass
-
-
-def send_apm_event(peer_id, event_param):
-    event.Event(peer_id, event_param)
-
-
 # ------------------- data utils ----------------------------
 
 def is_hex(s):
@@ -525,9 +514,3 @@ def create_invoke_result_specific_case(confirmed_transaction_list, invoke_result
     for tx in confirmed_transaction_list:
         invoke_results[tx.tx_hash] = invoke_result
     return invoke_results
-
-
-if not conf.MONITOR_LOG:
-    apm_event = no_send_apm_event
-else:
-    apm_event = send_apm_event

--- a/loopchain/utils/loggers/configuration.py
+++ b/loopchain/utils/loggers/configuration.py
@@ -14,15 +14,15 @@
 
 import logging
 import logging.handlers
-import coloredlogs
-import verboselogs
 import os
 import sys
 import traceback
-
 from functools import partial, reduce
 from operator import or_
-from fluent import sender
+
+import coloredlogs
+import verboselogs
+
 from loopchain import configure as conf
 from .sized_timed_file_handler import SizedTimedRotatingFileHandler
 
@@ -44,9 +44,6 @@ class LogConfiguration:
         self.log_file_rotate_max_bytes = 0
         self.log_file_rotate_backup_count = 0
         self.log_file_rotate_utf = False
-        self.log_monitor = False
-        self.log_monitor_host = None
-        self.log_monitor_port = None
         self.is_leader = False
 
         self._log_level = None
@@ -75,9 +72,6 @@ class LogConfiguration:
                         handler.addFilter(self._root_stream_filter)
         else:
             logger.setLevel(self._log_level)
-
-        if self.log_monitor:
-            sender.setup('loopchain', host=self.log_monitor_host, port=self.log_monitor_port)
 
     def _update_log_color_set(self, logger):
         # level SPAM value is 5

--- a/loopchain/utils/loggers/configuration_others.py
+++ b/loopchain/utils/loggers/configuration_others.py
@@ -21,10 +21,6 @@ preset_others = LogConfiguration()
 
 
 def update_other_loggers():
-    preset_others.log_monitor = conf.MONITOR_LOG
-    preset_others.log_monitor_host = conf.MONITOR_LOG_HOST
-    preset_others.log_monitor_port = conf.MONITOR_LOG_PORT
-
     if get_preset_type() == PresetType.develop:
         preset_others.log_level = logging.WARNING
         preset_others.log_color = True

--- a/loopchain/utils/loggers/configuration_presets.py
+++ b/loopchain/utils/loggers/configuration_presets.py
@@ -81,10 +81,6 @@ def update_preset(update_logger=True):
     preset.log_file_rotate_utf = conf.LOG_FILE_ROTATE_UTC
     preset.log_file_rotate_when = conf.LOG_FILE_ROTATE_WHEN
 
-    preset.log_monitor = conf.MONITOR_LOG
-    preset.log_monitor_host = conf.MONITOR_LOG_HOST
-    preset.log_monitor_port = conf.MONITOR_LOG_PORT
-
     if preset is develop:
         preset.log_level = conf.LOOPCHAIN_DEVELOP_LOG_LEVEL
     else:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ grpcio-tools==1.27.2
 protobuf==3.11.3
 coloredlogs==14.0
 earlgrey>=0.0.4
-fluent-logger==0.9.5
 jsonrpcclient[aiohttp]==3.3.5
 jsonrpcserver==4.1.2
 plyvel>=1.0.5


### PR DESCRIPTION
# Goal
- Remove dependency: `fluent-logger`

# Reason
- Fluentd is no longer used in Loopchain.
- Resolve conflict of the dependencies between Loopchain and ICON-Service (on `msgpack`)