### PR TITLE
[LC-945] Integrate between the `icon-service` and the `Siever`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ install: $(INSTALL_REQUIRES)
 	$(PIP_INSTALL_CMD)
 
 requires-dev:
-	$(PIP_INSTALL) git+https://github.com/icon-project/icon-service.git@develop
-	$(PIP_INSTALL) git+https://github.com/icon-project/icon-rpc-server.git@develop
+	$(PIP_INSTALL) git+https://github.com/icon-project/icon-service.git@support_lft
+	$(PIP_INSTALL) git+https://github.com/icon-project/icon-commons.git@master
 
 ## pip install packages for develop
 develop: $(INSTALL_DEVELOP_REQUIRES)

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ install: $(INSTALL_REQUIRES)
 
 requires-dev:
 	$(PIP_INSTALL) git+https://github.com/icon-project/icon-service.git@support_lft
-	$(PIP_INSTALL) git+https://github.com/icon-project/icon-commons.git@master
+	$(PIP_INSTALL) git+https://github.com/icon-project/icon-rpc-server.git@develop
 
 ## pip install packages for develop
 develop: $(INSTALL_DEVELOP_REQUIRES)

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -1360,6 +1360,16 @@ class BlockChain:
             tx_receipt["blockHash"] = new_block.header.hash.hex()
 
         self.__invoke_results[new_block.header.hash] = (tx_receipts, next_prep)
+
+        request = {
+            "blockHeight": _block.header.height,
+            "oldBlockHash": _block.header.hash.hex(),
+            "newBlockHash": new_block.header.hash.hex()
+        }
+        request = convert_params(request, ParamType.change_block_hash)
+        response: dict = cast(dict, stub.sync_task().change_block_hash(request))
+        response_to_json_query(response)
+
         return new_block, tx_receipts
 
     def __write_preps(self, preps: list, next_reps_hash):

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -640,9 +640,8 @@ class BlockChain:
         tx_queue = self.__tx_queue
 
         for index, tx in enumerate(block.body.transactions.values()):
+            receipt = receipts[index]
             tx_hash = tx.hash.hex()
-            receipt = receipts[tx_hash]
-
             tx_serializer = TransactionSerializer.new(tx.version, tx.type(), self.__tx_versioner)
             tx_info = {
                 'block_hash': block.header.hash.hex(),
@@ -1158,7 +1157,7 @@ class BlockChain:
         new_block = block_builder.build()
         self.__block_manager.set_old_block_hash(new_block.header.height, new_block.header.hash, block.header.hash)
 
-        for tx_receipt in tx_receipts.values():
+        for tx_receipt in tx_receipts:
             tx_receipt["blockHash"] = new_block.header.hash.hex()
 
         self.__invoke_results[new_block.header.hash] = (tx_receipts, None)
@@ -1214,41 +1213,6 @@ class BlockChain:
         block_builder.reps = reps
         block_builder.next_reps = next_preps
         block_builder.next_reps_hash = next_preps_hash
-
-    def _process_added_transactions(self,
-                                    block_builder: BlockBuilder,
-                                    added_transactions: dict,
-                                    tx_receipts: dict,
-                                    is_block_editable: bool):
-        if is_block_editable:
-            original_tx_length: int = len(block_builder.transactions)
-            invoked_tx_length: int = len(tx_receipts) - len(added_transactions)
-            if original_tx_length > invoked_tx_length:
-                # restore tx status to normal and remove tx that dropped in block_builder
-                utils.logger.debug(f"_process_added_transactions() : origin tx length = {original_tx_length}, "
-                                   f"after invoke tx length = {invoked_tx_length}, "
-                                   f"added_transactions length = {len(added_transactions)}")
-                dropped_transactions: List[Transaction] = []
-                for txhash, tx in reversed(block_builder.transactions.items()):  # type: Hash32, Transaction
-                    if txhash.hex() not in tx_receipts:
-                        dropped_transactions.append(tx)
-                        original_tx_length -= 1
-                        if original_tx_length == invoked_tx_length:
-                            break
-
-                for tx in dropped_transactions:  # type: Transaction
-                    self.__block_manager.restore_tx_status(tx)
-                    block_builder.transactions.pop(tx.hash)
-                utils.logger.debug(f"_process_added_transactions() dropped tx length = {len(dropped_transactions)}")
-
-        if added_transactions:
-            # add added_transactions to block_builder.transactions
-            for tx_data in added_transactions.values():  # type: dict
-                tx_version, tx_type = self.__tx_versioner.get_version(tx_data)
-                ts = TransactionSerializer.new(tx_version, tx_type, self.__tx_versioner)
-                tx = ts.from_(tx_data)
-                block_builder.transactions[tx.hash] = tx
-                block_builder.transactions.move_to_end(tx.hash, last=False)  # move to first
 
     def score_invoke(self,
                      _block: Block,
@@ -1312,12 +1276,7 @@ class BlockChain:
         stub = StubCollection().icon_score_stubs[ChannelProperty().name]
         response: dict = cast(dict, stub.sync_task().invoke(request))
         response_to_json_query(response)
-
-        tx_receipts_origin = response.get("txResults")
-        if not isinstance(tx_receipts_origin, dict):
-            tx_receipts: dict = {tx_receipt['txHash']: tx_receipt for tx_receipt in cast(list, tx_receipts_origin)}
-        else:
-            tx_receipts: dict = tx_receipts_origin
+        tx_receipts = response.get("txResults")
 
         block_builder = BlockBuilder.from_new(_block, self.__tx_versioner)
         block_builder.reset_cache()
@@ -1336,9 +1295,6 @@ class BlockChain:
                 # TODO : need check that legacy useless after upgrade to block v0.4
                 self._process_next_prep_legacy(_block, block_builder, next_prep)
 
-        added_transactions = response.get("addedTransactions")
-        self._process_added_transactions(block_builder, added_transactions, tx_receipts, is_block_editable)
-
         block_builder.commit_state = {
             ChannelProperty().name: response['stateRootHash']
         }
@@ -1356,7 +1312,7 @@ class BlockChain:
             self.__write_preps(preps=next_prep["preps"], next_reps_hash=new_block.header.next_reps_hash)
         self.__block_manager.set_old_block_hash(new_block.header.height, new_block.header.hash, _block.header.hash)
 
-        for tx_receipt in tx_receipts.values():
+        for tx_receipt in tx_receipts:
             tx_receipt["blockHash"] = new_block.header.hash.hex()
 
         self.__invoke_results[new_block.header.hash] = (tx_receipts, next_prep)

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -1317,15 +1317,6 @@ class BlockChain:
 
         self.__invoke_results[new_block.header.hash] = (tx_receipts, next_prep)
 
-        request = {
-            "blockHeight": _block.header.height,
-            "oldBlockHash": _block.header.hash.hex(),
-            "newBlockHash": new_block.header.hash.hex()
-        }
-        request = convert_params(request, ParamType.change_block_hash)
-        response: dict = cast(dict, stub.sync_task().change_block_hash(request))
-        response_to_json_query(response)
-
         return new_block, tx_receipts
 
     def __write_preps(self, preps: list, next_reps_hash):

--- a/loopchain/blockchain/blocks/v0_3/block_builder.py
+++ b/loopchain/blockchain/blocks/v0_3/block_builder.py
@@ -51,7 +51,7 @@ class BlockBuilder(BaseBlockBuilder):
         if len(self.transactions) != len(receipts):
             raise RuntimeError("Transactions and Receipts are not matched.")
 
-        self._receipts = [dict(receipts[tx_hash.hex()]) for tx_hash in self.transactions]
+        self._receipts = receipts
         for receipt in self._receipts:
             receipt.pop("blockHash", None)
 

--- a/loopchain/blockchain/epoch.py
+++ b/loopchain/blockchain/epoch.py
@@ -2,10 +2,10 @@
 Candidate Blocks, Quorum, Votes and Leader Complaints.
 """
 
-import time
 import traceback
 from typing import Dict, Optional, TYPE_CHECKING
 
+import time
 from pkg_resources import parse_version
 
 from loopchain import utils, configure as conf

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -636,11 +636,9 @@ class ChannelService:
         except KeyError:
             old_block_hash = new_block_hash
 
-        logging.debug(f"Block Hash : {old_block_hash} -> {new_block_hash}")
         request = {
             "blockHeight": block.header.height,
-            "oldBlockHash": old_block_hash.hex(),
-            "newBlockHash": new_block_hash.hex()
+            "blockHash": new_block_hash.hex()
         }
         request = convert_params(request, ParamType.write_precommit_state)
 

--- a/loopchain/peer/consensus_siever.py
+++ b/loopchain/peer/consensus_siever.py
@@ -213,9 +213,10 @@ class ConsensusSiever(ConsensusBase):
 
             util.logger.spam(f"self._block_manager.epoch.leader_id: {self._block_manager.epoch.leader_id}")
             candidate_block = self.__build_candidate_block(block_builder)
-            candidate_block, invoke_results = self._blockchain.score_invoke(
+            candidate_block, _ = self._blockchain.score_invoke(
                 candidate_block, self._blockchain.latest_block,
-                is_block_editable=True, is_unrecorded_block=is_unrecorded_block)
+                is_block_editable=True, is_unrecorded_block=is_unrecorded_block
+            )
 
             util.logger.spam(f"candidate block : {candidate_block.header}")
             self._block_manager.candidate_blocks.add_block(

--- a/loopchain/scoreservice/icon_inner_service.py
+++ b/loopchain/scoreservice/icon_inner_service.py
@@ -29,6 +29,10 @@ class IconScoreInnerTask:
         pass
 
     @message_queue_task
+    async def pre_invoke(self, request: dict) -> dict:
+        pass
+
+    @message_queue_task
     async def invoke(self, request: dict) -> dict:
         pass
 

--- a/loopchain/scoreservice/icon_inner_service.py
+++ b/loopchain/scoreservice/icon_inner_service.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Union
 
 from earlgrey import message_queue_task, MessageQueueStub
 
@@ -52,7 +53,7 @@ class IconScoreInnerTask:
         pass
 
     @message_queue_task
-    async def change_block_hash(self, params) -> dict:
+    async def change_block_hash(self, request: dict) -> Union[dict, str]:
         pass
 
     @message_queue_task

--- a/loopchain/utils/icon_service/converter.py
+++ b/loopchain/utils/icon_service/converter.py
@@ -36,6 +36,7 @@ class ParamType(Enum):
     send_tx_response = 14
     roll_back = 15
     change_block_hash = 16
+    pre_invoke = 17
 
 
 class ValueType(Enum):
@@ -265,6 +266,8 @@ templates[ParamType.write_precommit_state] = {
 templates[ParamType.remove_precommit_state] = templates[ParamType.write_precommit_state]
 
 templates[ParamType.roll_back] = templates[ParamType.write_precommit_state]
+
+templates[ParamType.pre_invoke] = templates[ParamType.write_precommit_state]
 
 templates[ParamType.get_block_by_hash_request] = {
     "hash": ValueType.hex_number

--- a/loopchain/utils/icon_service/converter.py
+++ b/loopchain/utils/icon_service/converter.py
@@ -35,6 +35,7 @@ class ParamType(Enum):
     get_tx_result_response = 13
     send_tx_response = 14
     roll_back = 15
+    change_block_hash = 16
 
 
 class ValueType(Enum):
@@ -297,3 +298,9 @@ templates[ParamType.get_tx_by_hash_response] = {
 }
 
 templates[ParamType.send_tx_response] = ValueType.hex_0x_hash_number
+
+templates[ParamType.change_block_hash] = {
+    "blockHeight": ValueType.hex_0x_number,
+    "oldBlockHash": ValueType.hex_number,
+    "newBlockHash": ValueType.hex_number
+}

--- a/testcase/unittest/test_block.py
+++ b/testcase/unittest/test_block.py
@@ -230,7 +230,7 @@ class TestBlock(unittest.TestCase):
         test_signer = Signer.from_prikey(os.urandom(32))
         tx_versioner = TransactionVersioner()
 
-        dummy_receipts = {}
+        dummy_receipts = []
         block_builder = BlockBuilder.new(block_version, tx_versioner)
         for i in range(5):
             tx_builder = TransactionBuilder.new("0x3", None, tx_versioner)
@@ -243,10 +243,7 @@ class TestBlock(unittest.TestCase):
 
             tx_serializer = TransactionSerializer.new(tx.version, tx.type(), tx_versioner)
             block_builder.transactions[tx.hash] = tx
-            dummy_receipts[tx.hash.hex()] = {
-                "dummy_receipt": "dummy",
-                "tx_dumped": tx_serializer.to_full_data(tx)
-            }
+            dummy_receipts.append({"dummy_receipt": "dummy", "tx_dumped": tx_serializer.to_full_data(tx)})
 
         next_leader = ExternalAddress.fromhex("hx00112233445566778899aabbccddeeff00112233")
 
@@ -298,7 +295,7 @@ class TestBlock(unittest.TestCase):
         test_signer = Signer.from_prikey(os.urandom(32))
         tx_versioner = TransactionVersioner()
 
-        dummy_receipts = {}
+        dummy_receipts = []
         block_builder = BlockBuilder.new(block_version, tx_versioner)
         for i in range(5):
             tx_builder = TransactionBuilder.new("0x3", None, tx_versioner)
@@ -311,10 +308,7 @@ class TestBlock(unittest.TestCase):
 
             tx_serializer = TransactionSerializer.new(tx.version, tx.type(), tx_versioner)
             block_builder.transactions[tx.hash] = tx
-            dummy_receipts[tx.hash.hex()] = {
-                "dummy_receipt": "dummy",
-                "tx_dumped": tx_serializer.to_full_data(tx)
-            }
+            dummy_receipts.append({"dummy_receipt": "dummy", "tx_dumped": tx_serializer.to_full_data(tx)})
 
         next_leader = ExternalAddress.fromhex("hx00112233445566778899aabbccddeeff00112233")
 


### PR DESCRIPTION
Integrate between the `icon-service`, which it can invoke 2-depth, and the `Siever`.

- Add logic to request change the key of `precommit_data_mapper` from old block hash to new block hash.
- Remove `oldBlockHash` from interface `write_precommit_state`.
- Replace the branch of the `icon-service` from the `develop` to the `support_lft` for the test of loopchain 3.0.
- Edit logic to invoke by changing the data specification of `response`.
- Add logic `PreInvoke`.