### PR TITLE
[IS-1059] close db gracefully when recv SIGINT, SIGTERM

### DIFF
--- a/loopchain/baseservice/broadcast_scheduler.py
+++ b/loopchain/baseservice/broadcast_scheduler.py
@@ -445,7 +445,8 @@ class _BroadcastSchedulerMp(BroadcastScheduler):
         def _signal_handler(signal_num, frame):
             signal.signal(signal.SIGTERM, original_sigterm_handler)
             signal.signal(signal.SIGINT, original_sigint_handler)
-            logging.error(f"BroadcastScheduler process({channel}) has been received signal({signal_num})")
+            logging.error(f"BroadcastScheduler process({channel}) has been received "
+                          f"signal({repr(signal.Signals(signal_num))})")
             broadcast_queue.put((None, None))
             broadcaster.stop()
 

--- a/loopchain/baseservice/rest_service.py
+++ b/loopchain/baseservice/rest_service.py
@@ -42,7 +42,7 @@ class RestService(CommonProcess):
         server = CommonSubprocess(args)
         api_port = self._port + conf.PORT_DIFF_REST_SERVICE_CONTAINER
         server.set_proctitle(f"{setproctitle.getproctitle()} RestServer api_port({api_port})")
-        logging.info(f'RestService run complete port {self._port}')
+        logging.info(f'RestService run complete port {api_port}')
 
         # complete init
         event.set()

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -235,7 +235,7 @@ class BlockChain:
         return self._blockchain_store
 
     def close_blockchain_store(self):
-        print(f"close blockchain_store = {self._blockchain_store}")
+        logging.info(f"close_blockchain_store() : {self._blockchain_store}")
         if self._blockchain_store:
             self._blockchain_store.close()
             self._blockchain_store: KeyValueStore = None

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -62,7 +62,7 @@ class BlockManager:
         self.candidate_blocks = CandidateBlocks(self.blockchain)
         self.__block_height_sync_bad_targets = {}
         self.__block_height_sync_lock = threading.Lock()
-        self.__block_height_thread_pool = ThreadPoolExecutor(1, 'BlockHeightSyncThread')
+        self.__block_height_thread_pool: ThreadPoolExecutor = ThreadPoolExecutor(1, 'BlockHeightSyncThread')
         self.__block_height_future: Future = None
         self.set_peer_type(loopchain_pb2.PEER)
         self.__service_status = status_code.Service.online
@@ -757,11 +757,15 @@ class BlockManager:
         util.logger.info(f"Epoch height({self.epoch.height}), leader ({self.epoch.leader_id})")
 
     def stop(self):
-        # for reuse key value store when restart channel.
-        self.blockchain.close_blockchain_store()
+        self.__block_height_thread_pool.shutdown()
 
         if self.consensus_algorithm:
             self.consensus_algorithm.stop()
+
+        # close store(aka. leveldb) after cleanup all threads
+        # because hard crashes may occur.
+        # https://plyvel.readthedocs.io/en/latest/api.html#DB.close
+        self.blockchain.close_blockchain_store()
 
     def add_complain(self, vote: LeaderVote):
         util.logger.spam(f"add_complain vote({vote})")

--- a/loopchain/peer/peer_service.py
+++ b/loopchain/peer/peer_service.py
@@ -14,7 +14,7 @@
 """loopchain main peer service.
 It has secure outer service for p2p consensus and status monitoring.
 And also has insecure inner service for inner process modules."""
-
+import asyncio
 import getpass
 import logging
 import multiprocessing
@@ -220,25 +220,32 @@ class PeerService:
             loop.run_forever()
         finally:
             loop.run_until_complete(loop.shutdown_asyncgens())
+            self._cleanup(loop)
             loop.close()
 
-        # process monitor must stop monitoring before any subprocess stop
-        # Monitor().stop()
-
         logging.info("Peer Service Ended.")
-        if self._rest_service is not None:
-            self._rest_service.stop()
 
     def close(self):
-        async def _close():
-            for channel_stub in StubCollection().channel_stubs.values():
-                await channel_stub.async_task().stop("Close")
+        self._inner_service.loop.stop()
 
-            self.p2p_server_stop()
-            loop.stop()
+    def _cleanup(self, loop):
+        logging.info("_cleanup() Peer Resources.")
+        for task in asyncio.Task.all_tasks(loop):
+            if task.done():
+                continue
+            task.cancel()
+            try:
+                loop.run_until_complete(task)
+            except asyncio.CancelledError as e:
+                logging.info(f"_cleanup() task : {task}, error : {e}")
 
-        loop = self._inner_service.loop
-        loop.create_task(_close())
+        self.p2p_server_stop()
+        logging.info("_cleanup() p2p server.")
+
+        if self._rest_service is not None:
+            self._rest_service.stop()
+            self._rest_service.wait()
+            logging.info("_cleanup() Rest Service.")
 
     async def serve_channels(self):
         for i, channel_name in enumerate(self._channel_infos):


### PR DESCRIPTION
# db crash may occur when recv SIGINT, SIGTERM
https://plyvel.readthedocs.io/en/latest/api.html#DB.close

# cleanup resources
fixed to close db at last of cleanup order.
cleanup order :
 1. child process
 1. loop stop
 1. cancel tasks
 1. threads(timer service, broadcast scheduler, threadpoolexecutor)
 1. key_value_store(leveldb)
