### PR TITLE
[LC-984] Replace the branch of the `icon-service`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ install: $(INSTALL_REQUIRES)
 	$(PIP_INSTALL_CMD)
 
 requires-dev:
-	$(PIP_INSTALL) git+https://github.com/icon-project/icon-service.git@develop
+	$(PIP_INSTALL) git+https://github.com/icon-project/icon-service.git@support_lft
 	$(PIP_INSTALL) git+https://github.com/icon-project/icon-commons.git@master
 	$(PIP_INSTALL) git+https://github.com/icon-project/icon-rpc-server.git@develop
 	$(PIP_INSTALL) git+https://github.com/icon-project/lft2.git@develop#egg=name[app]


### PR DESCRIPTION
Replace the branch of the `icon-service` from the `develop` to the `support_lft` for the test of loopchain 3.0.