### PR TITLE
[LC-973] Edit params of Block & Vote 1.0 (consensus_id, stateHash)

### DIFF
--- a/loopchain/blockchain/types.py
+++ b/loopchain/blockchain/types.py
@@ -78,6 +78,13 @@ class VarBytes(Bytes):
 class Hash32(VarBytes):
     size = 32
 
+    def __xor__(self, other: 'Hash32'):
+        me = bytearray(self)
+        for idx, byte in enumerate(other):
+            me[idx] ^= byte
+
+        return Hash32(me)
+
 
 class Address(Bytes, metaclass=ABCMeta):
     size = 20

--- a/loopchain/blockchain/votes/v1_0/vote.py
+++ b/loopchain/blockchain/votes/v1_0/vote.py
@@ -9,7 +9,8 @@ class BlockVote(Vote):
     LazyVote = Hash32(bytes([255] * 32))
 
     def __init__(self, data_id: Hash32, commit_id: Hash32, voter_id: ExternalAddress, epoch_num: int, round_num: int,
-                 state_hash: Hash32, receipt_hash: Hash32, timestamp: int, signature: Signature, height: int, _hash=None):
+                 state_hash: Hash32, receipt_hash: Hash32, next_validators_hash: Hash32,
+                 timestamp: int, signature: Signature, height: int, _hash=None):
         """Vote.
 
         :param state_hash:
@@ -34,6 +35,7 @@ class BlockVote(Vote):
         # Not in Interface
         self._state_hash: Hash32 = state_hash
         self._receipt_hash: Hash32 = receipt_hash
+        self._next_validators_hash: Hash32 = next_validators_hash
         self._timestamp: int = timestamp
         self._signature: Signature = signature
 
@@ -54,7 +56,8 @@ class BlockVote(Vote):
                f"epoch_num={self._epoch_num}, " \
                f"round_num={self._round_num}, " \
                f"state_hash={self._state_hash}, " \
-               f"receipt_hash={self._receipt_hash}, " \
+               f"receipt_hash={self._receipt_hash}, "\
+               f"next_validators_hash={self._next_validators_hash}, " \
                f"timestamp={self._timestamp}, " \
                f"signature={self._signature}, " \
                f"hash={self._hash})"
@@ -80,6 +83,10 @@ class BlockVote(Vote):
         return self._commit_id
 
     @property
+    def consensus_id(self) -> Hash32:
+        return self._data_id ^ self._state_hash ^ self._receipt_hash ^ self._next_validators_hash
+
+    @property
     def voter_id(self) -> ExternalAddress:
         return self._voter_id
 
@@ -98,6 +105,10 @@ class BlockVote(Vote):
     @property
     def receipt_hash(self) -> Hash32:
         return self._receipt_hash
+
+    @property
+    def next_validators_hash(self) -> Hash32:
+        return self._next_validators_hash
 
     @property
     def timestamp(self) -> int:
@@ -124,6 +135,7 @@ class BlockVote(Vote):
             "commitHash": self._commit_id.hex_0x(),
             "stateHash": self._state_hash.hex_0x(),
             "receiptHash": self._receipt_hash.hex_0x(),
+            "nextValidatorsHash": self._next_validators_hash.hex_0x(),
             "epoch": hex(self._epoch_num),
             "round": hex(self._round_num),
             "signature": self._signature.to_base64str()
@@ -134,6 +146,7 @@ class BlockVote(Vote):
         return cls(
             state_hash=Hash32.fromhex(data["stateHash"]),
             receipt_hash=Hash32.fromhex(data["receiptHash"]),
+            next_validators_hash=Hash32.fromhex(data["nextValidatorsHash"]),
             data_id=Hash32.fromhex(data["blockHash"]),
             commit_id=Hash32.fromhex(data["commitHash"]),
             voter_id=ExternalAddress.fromhex_address(data["validator"]),

--- a/loopchain/blockchain/votes/v1_0/vote_factory.py
+++ b/loopchain/blockchain/votes/v1_0/vote_factory.py
@@ -17,7 +17,7 @@ class BlockVoteFactory(VoteFactory):
         self._voter_id = ExternalAddress.fromhex(self._signer.address)
 
     def _get_signature(self, voter_id, height: int, commit_id, data_id,
-                       epoch_num, state_hash, receipt_hash, round_num, timestamp) -> Signature:
+                       epoch_num, state_hash, receipt_hash, next_validators_hash, round_num, timestamp) -> Signature:
         origin_data = {
             "validator": voter_id.hex_hx(),
             "timestamp": hex(timestamp),
@@ -26,6 +26,7 @@ class BlockVoteFactory(VoteFactory):
             "commitHash": Hash32(commit_id),
             "stateHash": state_hash,
             "receiptHash": receipt_hash,
+            "nextValidatorsHash": next_validators_hash,
             "epoch": epoch_num,
             "round": round_num
         }
@@ -47,6 +48,7 @@ class BlockVoteFactory(VoteFactory):
             epoch_num=epoch_num,
             state_hash=invoke_data.state_hash,
             receipt_hash=invoke_data.receipt_hash,
+            next_validators_hash=invoke_data.next_validators_hash,
             round_num=round_num,
             timestamp=timestamp
         )
@@ -55,6 +57,7 @@ class BlockVoteFactory(VoteFactory):
             voter_id=self._voter_id,
             receipt_hash=invoke_data.receipt_hash,
             state_hash=invoke_data.state_hash,
+            next_validators_hash=invoke_data.next_validators_hash,
             data_id=Hash32(data_id),
             commit_id=Hash32(commit_id),
             timestamp=timestamp,
@@ -76,6 +79,7 @@ class BlockVoteFactory(VoteFactory):
             epoch_num=epoch_num,
             state_hash=BlockVote.NoneVote,
             receipt_hash=BlockVote.NoneVote,
+            next_validators_hash=BlockVote.NoneVote,
             round_num=round_num,
             timestamp=timestamp
         )
@@ -84,6 +88,7 @@ class BlockVoteFactory(VoteFactory):
             height=0,
             receipt_hash=BlockVote.NoneVote,
             state_hash=BlockVote.NoneVote,
+            next_validators_hash=BlockVote.NoneVote,
             data_id=BlockVote.NoneVote,
             commit_id=BlockVote.NoneVote,
             voter_id=self._voter_id,
@@ -98,11 +103,12 @@ class BlockVoteFactory(VoteFactory):
         signature = self._get_signature(
             height=0,
             voter_id=self._voter_id,
-            commit_id=BlockVote.NoneVote,
-            data_id=BlockVote.NoneVote,
+            commit_id=BlockVote.LazyVote,
+            data_id=BlockVote.LazyVote,
             epoch_num=epoch_num,
-            state_hash=BlockVote.NoneVote,
-            receipt_hash=BlockVote.NoneVote,
+            state_hash=BlockVote.LazyVote,
+            receipt_hash=BlockVote.LazyVote,
+            next_validators_hash=BlockVote.LazyVote,
             round_num=round_num,
             timestamp=timestamp
         )
@@ -111,6 +117,7 @@ class BlockVoteFactory(VoteFactory):
             height=0,
             receipt_hash=BlockVote.LazyVote,
             state_hash=BlockVote.LazyVote,
+            next_validators_hash=BlockVote.LazyVote,
             data_id=BlockVote.LazyVote,
             commit_id=BlockVote.LazyVote,
             voter_id=self._voter_id,

--- a/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
+++ b/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
@@ -46,6 +46,7 @@ class TestBlockFactory:
                 "commitHash": "0x0399e62d77438f940dd207a2ba4593d2b231214606140c0ee6fa8f4fa7ff1d3d",
                 "stateHash": "0x0399e62d77438f940dd207a2ba4593d2b231214606140c0ee6fa8f4fa7ff1d3e",
                 "receiptHash": "0x0399e62d77438f940dd207a2ba4593d2b231214606140c0ee6fa8f4fa7ff1d3f",
+                "nextValidatorsHash": "0x0399e62d77438f940dd207a2ba4593d2b231214606140c0ee6fa8f4fa7ff1d3f",
                 "epoch": "0x2",
                 "round": "0x1",
                 "signature": "aC8qGOAO5Fz/lNVZW5nHdR8MiNj5WaDr+2IimKiYJ9dAXLQoaolOU/"

--- a/testcase/unittest/blockchain/test_invoke_result.py
+++ b/testcase/unittest/blockchain/test_invoke_result.py
@@ -215,6 +215,7 @@ class TestInvokeRequest:
                 round_num=1,
                 state_hash=Hash32.new(),
                 receipt_hash=Hash32.new(),
+                next_validators_hash=Hash32.new(),
                 timestamp=1,
                 signature=Signature.new()
             ) for validator, vote_result in zip(validators, vote_results)

--- a/testcase/unittest/blockchain/votes/v1_0/test_vote.py
+++ b/testcase/unittest/blockchain/votes/v1_0/test_vote.py
@@ -51,7 +51,7 @@ class TestVote_v1_0:
         assert vote.id == vote.hash
 
     def test_consensus_hash(self, vote: BlockVote):
-        expected = vote.data_id ^ vote.receipt_hash ^ vote.state_hash ^ vote.next_validators_hash
+        expected = Hash32.fromhex("0x0000000000000000000000000000000000000000000000000000000000000007")
 
         assert isinstance(vote.consensus_id, Hash32)
         assert vote.consensus_id == expected


### PR DESCRIPTION
# Goal
- Add `consensus_id` to Vote 1.0
> This param is mandatory. Related PR: https://github.com/icon-project/LFT2/pull/27

- Edit `Block.prevStateHash` to `Block.stateHash`
> The state hash in a block indicates **current status of the block before txs not being executed**. 