### PR TITLE
[LC-954] Call PreInvoke

### DIFF
--- a/loopchain/blockchain/blocks/v1_0/block_factory.py
+++ b/loopchain/blockchain/blocks/v1_0/block_factory.py
@@ -9,28 +9,26 @@ from loopchain import utils
 from loopchain.blockchain.blocks.v1_0.block import Block, BlockHeader, BlockBody
 from loopchain.blockchain.blocks.v1_0.block_builder import BlockBuilder
 from loopchain.blockchain.blocks.v1_0.block_verifier import BlockVerifier
-from loopchain.blockchain.invoke_result import InvokePool, PreInvokeResponse
 from loopchain.blockchain.transactions import Transaction, TransactionVerifier, TransactionSerializer
 from loopchain.blockchain.types import BloomFilter, Hash32, TransactionStatusInQueue, ExternalAddress
 from loopchain.crypto.signature import Signer
-from loopchain.store.key_value_store import KeyValueStore
 
 if TYPE_CHECKING:
     from loopchain.blockchain.votes.v1_0.vote import BlockVote
+    from loopchain.blockchain.invoke_result import InvokePool, PreInvokeResponse
     from loopchain.baseservice.aging_cache import AgingCache
-    from loopchain.store.key_value_store_plyvel import KeyValueStorePlyvel
 
 
 class BlockFactory(DataFactory):
     NoneData = Hash32.empty()
     LazyData = Hash32(bytes([255] * 32))
 
-    def __init__(self, epoch_pool_with_app, tx_queue: 'AgingCache', blockchain, tx_versioner, invoke_pool: InvokePool, signer):
+    def __init__(self, epoch_pool_with_app, tx_queue: 'AgingCache', blockchain, tx_versioner, invoke_pool: 'InvokePool', signer):
         self._epoch_pool: EpochPool = epoch_pool_with_app
         self._tx_versioner = tx_versioner
 
         self._tx_queue: 'AgingCache' = tx_queue
-        self._invoke_pool: InvokePool = invoke_pool
+        self._invoke_pool: 'InvokePool' = invoke_pool
         self._blockchain = blockchain  # TODO: Will be replaced as DB Component
         self._last_block: Block = ""  # FIXME: store it in memory or get it from db
 
@@ -56,7 +54,7 @@ class BlockFactory(DataFactory):
         block_builder.fixed_timestamp = int(time.time() * 1_000_000)
         block_builder.prev_votes = prev_votes
 
-        pre_invoke_response: PreInvokeResponse = self._invoke_pool.prepare_invoke(
+        pre_invoke_response: 'PreInvokeResponse' = self._invoke_pool.prepare_invoke(
             block_height=data_number,
             block_hash=prev_id
         )

--- a/loopchain/blockchain/blocks/v1_0/block_factory.py
+++ b/loopchain/blockchain/blocks/v1_0/block_factory.py
@@ -23,7 +23,13 @@ class BlockFactory(DataFactory):
     NoneData = Hash32.empty()
     LazyData = Hash32(bytes([255] * 32))
 
-    def __init__(self, epoch_pool_with_app, tx_queue: 'AgingCache', blockchain, tx_versioner, invoke_pool: 'InvokePool', signer):
+    def __init__(self,
+                 epoch_pool_with_app,
+                 tx_queue: 'AgingCache',
+                 blockchain,
+                 tx_versioner,
+                 invoke_pool: 'InvokePool',
+                 signer):
         self._epoch_pool: EpochPool = epoch_pool_with_app
         self._tx_versioner = tx_versioner
 

--- a/loopchain/blockchain/blocks/v1_0/block_factory.py
+++ b/loopchain/blockchain/blocks/v1_0/block_factory.py
@@ -77,12 +77,15 @@ class BlockFactory(DataFactory):
             block_builder.prev_state_hash = prev_vote.state_hash
             block_builder.receipts = prev_vote.receipt_hash
             block_builder.next_validators_hash = prev_vote.next_validators_hash
-        else:
+        elif data_number == 1:
             # FIXME: Genesis Block has no prev votes. Retrieve genesis invoke data
             invoke_data = self._invoke_pool.get_invoke_data(0, 0)
             block_builder.prev_state_hash = invoke_data.state_hash
             block_builder.receipts = invoke_data.receipt_hash
             block_builder.next_validators_hash = invoke_data.next_validators_hash
+        else:
+            from loopchain import utils
+            utils.exit_and_msg("Not found prev_votes in candidate block. \nShutdown Loopchain Node...")
 
         block_builder.epoch = epoch_num
         block_builder.round = round_num

--- a/loopchain/blockchain/blocks/v1_0/block_factory.py
+++ b/loopchain/blockchain/blocks/v1_0/block_factory.py
@@ -56,7 +56,12 @@ class BlockFactory(DataFactory):
         block_builder.fixed_timestamp = int(time.time() * 1_000_000)
         block_builder.prev_votes = prev_votes
 
-        invoke_data: InvokeData = self._invoke_pool.prepare_invoke(epoch_num, round_num)
+        invoke_data: InvokeData = self._invoke_pool.prepare_invoke(
+            block_height=data_number,
+            block_hash=prev_id,
+            epoch_num=epoch_num,
+            round_num=round_num
+        )
         self._add_tx_to_block(block_builder, invoke_data.added_transactions)
 
         # ConsensusSiever.__build_candidate_block

--- a/loopchain/blockchain/blocks/v1_0/block_factory.py
+++ b/loopchain/blockchain/blocks/v1_0/block_factory.py
@@ -36,7 +36,6 @@ class BlockFactory(DataFactory):
         self._tx_queue: 'AgingCache' = tx_queue
         self._invoke_pool: 'InvokePool' = invoke_pool
         self._blockchain = blockchain  # TODO: Will be replaced as DB Component
-        self._last_block: Block = ""  # FIXME: store it in memory or get it from db
 
         # From BlockBuilder
         self._signer: Signer = signer

--- a/loopchain/blockchain/blocks/v1_0/block_factory.py
+++ b/loopchain/blockchain/blocks/v1_0/block_factory.py
@@ -78,9 +78,11 @@ class BlockFactory(DataFactory):
             block_builder.receipts = prev_vote.receipt_hash
             block_builder.next_validators_hash = prev_vote.next_validators_hash
         else:
-            block_builder.prev_state_hash = Hash32.empty()
-            block_builder.receipts = Hash32.empty()
-            block_builder.next_validators_hash = Hash32.empty()
+            # FIXME: Genesis Block has no prev votes. Retrieve genesis invoke data
+            invoke_data = self._invoke_pool.get_invoke_data(0, 0)
+            block_builder.prev_state_hash = invoke_data.state_hash
+            block_builder.receipts = invoke_data.receipt_hash
+            block_builder.next_validators_hash = invoke_data.next_validators_hash
 
         block_builder.epoch = epoch_num
         block_builder.round = round_num

--- a/loopchain/blockchain/blocks/v1_0/block_verifier.py
+++ b/loopchain/blockchain/blocks/v1_0/block_verifier.py
@@ -2,24 +2,24 @@ from typing import TYPE_CHECKING
 
 from lft.consensus.messages.data import DataVerifier
 
-from loopchain.blockchain.invoke_result import InvokePool, InvokeData
 from loopchain.blockchain.transactions import TransactionVersioner
 
 if TYPE_CHECKING:
+    from loopchain.blockchain.invoke_result import InvokeData, InvokePool
     from loopchain.blockchain.blocks.v1_0.block import Block
 
 
 class BlockVerifier(DataVerifier):
     version = "1.0"
 
-    def __init__(self, tx_versioner: TransactionVersioner, invoke_pool: InvokePool):
-        self._invoke_pool: InvokePool = invoke_pool
+    def __init__(self, tx_versioner: TransactionVersioner, invoke_pool: 'InvokePool'):
+        self._invoke_pool: 'InvokePool' = invoke_pool
         self._tx_versioner: TransactionVersioner = tx_versioner
 
     async def verify(self, prev_data: 'Block', data: 'Block'):
         self._do_invoke(data)
 
-    def _do_invoke(self, block) -> InvokeData:
+    def _do_invoke(self, block) -> 'InvokeData':
         invoke_result = self._invoke_pool.invoke(block=block)
 
         return invoke_result

--- a/loopchain/blockchain/blocks/v1_0/block_verifier.py
+++ b/loopchain/blockchain/blocks/v1_0/block_verifier.py
@@ -2,7 +2,7 @@ from typing import TYPE_CHECKING
 
 from lft.consensus.messages.data import DataVerifier
 
-from loopchain.blockchain.invoke_result import InvokePool, InvokeRequest, InvokeData
+from loopchain.blockchain.invoke_result import InvokePool, InvokeData
 from loopchain.blockchain.transactions import TransactionVersioner
 
 if TYPE_CHECKING:
@@ -20,13 +20,6 @@ class BlockVerifier(DataVerifier):
         self._do_invoke(data)
 
     def _do_invoke(self, block) -> InvokeData:
-        invoke_request = InvokeRequest.from_block(block=block)
-        invoke_result = self._invoke_pool.invoke(
-            epoch_num=block.header.epoch,
-            round_num=block.header.round,
-            height=block.header.height,
-            current_validators_hash=block.header.validators_hash,
-            invoke_request=invoke_request
-        )
+        invoke_result = self._invoke_pool.invoke(block=block)
 
         return invoke_result

--- a/loopchain/blockchain/blocks/v1_0/block_verifier.py
+++ b/loopchain/blockchain/blocks/v1_0/block_verifier.py
@@ -24,6 +24,8 @@ class BlockVerifier(DataVerifier):
         invoke_result = self._invoke_pool.invoke(
             epoch_num=block.header.epoch,
             round_num=block.header.round,
+            height=block.header.height,
+            current_validators_hash=block.header.validators_hash,
             invoke_request=invoke_request
         )
 

--- a/loopchain/blockchain/invoke_result.py
+++ b/loopchain/blockchain/invoke_result.py
@@ -118,6 +118,40 @@ class InvokeRequest:
         )
 
 
+class PreInvokeResponse:
+    def __init__(self,
+                 added_transactions,
+                 validators_hash: Hash32):
+        self._added_txs = added_transactions
+        self._validators_hash: Hash32 = validators_hash
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}(" \
+            f"added_transactions={self._added_txs}," \
+            f"validators_hash={self._validators_hash})"
+
+    @property
+    def added_transactions(self):
+        return self._added_txs
+
+    @property
+    def validators_hash(self) -> Hash32:
+        return self._validators_hash
+
+    @classmethod
+    def from_dict(cls, pre_invoke_result: dict):
+        # FIXME: `currentRepsHash` and `addedTransactions` may always be returned after Rev.6.
+        added_txs: Dict[str, dict] = pre_invoke_result.get("addedTransactions", {})
+        validators_hash = pre_invoke_result.get("currentRepsHash")
+        validators_hash = Hash32.fromhex(validators_hash, ignore_prefix=True) \
+            if validators_hash else ChannelProperty().crep_root_hash
+
+        return cls(
+            added_transactions=added_txs,
+            validators_hash=validators_hash
+        )
+
+
 class InvokeData(Message):
     def __init__(self,
                  epoch_num: int,

--- a/loopchain/blockchain/invoke_result.py
+++ b/loopchain/blockchain/invoke_result.py
@@ -277,7 +277,7 @@ class InvokePool(MessagePool):
 
         return cast(InvokeData, self.get_message(id_))
 
-    def prepare_invoke(self, block_height: int, block_hash:Hash32) -> PreInvokeResponse:
+    def prepare_invoke(self, block_height: int, block_hash: Hash32) -> PreInvokeResponse:
         icon_service = StubCollection().icon_score_stubs[ChannelProperty().name]  # FIXME SINGLETON!
 
         request = {

--- a/loopchain/blockchain/invoke_result.py
+++ b/loopchain/blockchain/invoke_result.py
@@ -277,7 +277,7 @@ class InvokePool(MessagePool):
 
         return cast(InvokeData, self.get_message(id_))
 
-    def prepare_invoke(self, block_height: int, block_hash:Hash32, epoch_num: int, round_num: int) -> InvokeData:
+    def prepare_invoke(self, block_height: int, block_hash:Hash32) -> PreInvokeResponse:
         icon_service = StubCollection().icon_score_stubs[ChannelProperty().name]  # FIXME SINGLETON!
 
         request = {
@@ -285,12 +285,8 @@ class InvokePool(MessagePool):
             "blockHash": block_hash.hex()
         }
         pre_invoke_result = cast(dict, icon_service.sync_task().pre_invoke(request))
-        invoke_data: InvokeData = InvokeData.from_dict(
-            epoch_num=epoch_num, round_num=round_num, pre_invoke_result=pre_invoke_result
-        )
-        self.add_message(invoke_data)
 
-        return invoke_data
+        return PreInvokeResponse.from_dict(pre_invoke_result)
 
     def invoke(self, epoch_num: int, round_num: int, invoke_request: InvokeRequest) -> InvokeData:
         """Originated from `Blockchain.score_invoke`."""

--- a/loopchain/blockchain/invoke_result.py
+++ b/loopchain/blockchain/invoke_result.py
@@ -264,22 +264,19 @@ class InvokePool(MessagePool):
 
         return PreInvokeResponse.new(pre_invoke_result)
 
-    def invoke(self,
-               epoch_num: int,
-               round_num: int,
-               height: int,
-               current_validators_hash: Hash32,
-               invoke_request: InvokeRequest) -> InvokeData:
+    def invoke(self, block: 'Block') -> InvokeData:
         """Originated from `Blockchain.score_invoke`."""
+
+        invoke_request = InvokeRequest.from_block(block=block)
 
         icon_service = StubCollection().icon_score_stubs[ChannelProperty().name]  # FIXME SINGLETON!
         invoke_result_dict: dict = icon_service.sync_task().invoke(invoke_request.serialize())
 
         invoke_data = InvokeData.new(
-            epoch_num=epoch_num,
-            round_num=round_num,
-            height=height,
-            current_validators_hash=current_validators_hash,
+            epoch_num=block.header.epoch,
+            round_num=block.header.round,
+            height=block.header.height,
+            current_validators_hash=block.header.validators_hash,
             invoke_result=invoke_result_dict
         )
         self.add_message(invoke_data)

--- a/loopchain/blockchain/invoke_result.py
+++ b/loopchain/blockchain/invoke_result.py
@@ -3,7 +3,6 @@ from typing import TYPE_CHECKING, cast, Sequence, List, Union, Dict, OrderedDict
 from lft.consensus.messages.message import MessagePool, Message
 
 from loopchain.blockchain.blocks import BlockProverType
-from loopchain.blockchain.blocks import NextRepsChangeReason
 from loopchain.blockchain.blocks.v0_3 import BlockProver
 from loopchain.blockchain.transactions import TransactionSerializer, TransactionVersioner
 from loopchain.blockchain.types import Hash32, ExternalAddress
@@ -175,10 +174,6 @@ class InvokeData(Message):
         self._epoch_num: int = epoch_num
         self._round_num: int = round_num
         self._height = height
-        self._next_validators: Optional[list] = None
-        self._next_validators_hash: Hash32 = validators_hash
-        self._changed_reason: NextRepsChangeReason = NextRepsChangeReason.NoChange
-
         self._receipts: list = receipts
         self._state_hash: Optional[Hash32] = state_root_hash
 
@@ -186,7 +181,8 @@ class InvokeData(Message):
             reps = [ExternalAddress.fromhex(rep["id"]) for rep in next_validators_origin["nextReps"]]
             block_prover = BlockProver((rep.extend() for rep in reps), BlockProverType.Rep)
             self._next_validators_hash = block_prover.get_proof_root()
-            self._changed_reason = NextRepsChangeReason.convert_to_change_reason(next_validators_origin["state"])
+        else:
+            self._next_validators_hash: Hash32 = validators_hash
 
     def __repr__(self):
         return f"{self.__class__.__name__}(" \

--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -231,7 +231,6 @@ class ChannelService:
         self.__consensus_runner.start(event)
 
     def _generate_genesis_block(self):
-
         tx_versioner = TransactionVersioner()
         signer = ChannelProperty().peer_auth
 
@@ -249,7 +248,7 @@ class ChannelService:
         block_builder.signer = None
 
         peer_id = ExternalAddress.fromhex_address(signer.address)
-        block_builder.validators_hash = Hash32.empty()
+        block_builder.validators_hash = ChannelProperty().crep_root_hash
         block_builder.next_validators = [peer_id]
 
         block_builder.epoch = 0

--- a/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
+++ b/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
@@ -25,7 +25,7 @@ class TestBlockFactory:
         invoke_pool.prepare_invoke.return_value = InvokeData.from_dict(
             epoch_num=1,
             round_num=1,
-            query_result=icon_preinvoke
+            pre_invoke_result=icon_preinvoke
         )
         signer: Signer = Signer.new()
         epoch_pool = EpochPool()

--- a/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
+++ b/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
@@ -6,7 +6,7 @@ from lft.consensus.epoch import EpochPool
 from loopchain.baseservice.aging_cache import AgingCache
 from loopchain.blockchain import Hash32, ExternalAddress
 from loopchain.blockchain.blocks import v1_0
-from loopchain.blockchain.invoke_result import InvokePool, InvokeData
+from loopchain.blockchain.invoke_result import InvokePool, PreInvokeResponse
 from loopchain.blockchain.transactions import TransactionVersioner
 from loopchain.blockchain.votes.v1_0 import BlockVote
 from loopchain.crypto.signature import Signer
@@ -22,11 +22,7 @@ class TestBlockFactory:
         tx_versioner = TransactionVersioner()
 
         invoke_pool: InvokePool = mocker.MagicMock(InvokePool)
-        invoke_pool.prepare_invoke.return_value = InvokeData.new(
-            epoch_num=1,
-            round_num=1,
-            invoke_result=icon_preinvoke
-        )
+        invoke_pool.prepare_invoke.return_value = PreInvokeResponse.new(icon_preinvoke)
         signer: Signer = Signer.new()
         epoch_pool = EpochPool()
 

--- a/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
+++ b/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
@@ -22,7 +22,7 @@ class TestBlockFactory:
         tx_versioner = TransactionVersioner()
 
         invoke_pool: InvokePool = mocker.MagicMock(InvokePool)
-        invoke_pool.prepare_invoke.return_value = InvokeData.from_dict(
+        invoke_pool.prepare_invoke.return_value = InvokeData.new(
             epoch_num=1,
             round_num=1,
             invoke_result=icon_preinvoke

--- a/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
+++ b/testcase/unittest/blockchain/blocks/v1_0/test_block_factory.py
@@ -25,7 +25,7 @@ class TestBlockFactory:
         invoke_pool.prepare_invoke.return_value = InvokeData.from_dict(
             epoch_num=1,
             round_num=1,
-            pre_invoke_result=icon_preinvoke
+            invoke_result=icon_preinvoke
         )
         signer: Signer = Signer.new()
         epoch_pool = EpochPool()

--- a/testcase/unittest/blockchain/conftest.py
+++ b/testcase/unittest/blockchain/conftest.py
@@ -178,7 +178,6 @@ def icon_invoke() -> dict:
                 }
             ],
             "irep": "0x1",
-            "state": "0x0",
-            "rootHash": "c7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"
+            "state": "0x0"
         }
     }

--- a/testcase/unittest/blockchain/conftest.py
+++ b/testcase/unittest/blockchain/conftest.py
@@ -151,21 +151,6 @@ def icon_invoke() -> dict:
             }
         ],
         "stateRootHash": "c71303ef8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238",
-        "addedTransactions": {
-            "6804dd2ccd9a9d17136d687838aa09e02334cd4afa964d75993f18991ee874de": {
-                "version": "0x3",
-                "timestamp": "0x563a6cf330136",
-                "dataType": "base",
-                "data": {
-                    "prep": {
-                        "incentive": "0x1",
-                        "rewardRate": "0x1",
-                        "totalDelegation": "0x3872423746291",
-                        "value": "0x7800000"
-                    }
-                }
-            }
-        },
         "prep": {
             "nextReps": [
                 {

--- a/testcase/unittest/blockchain/conftest.py
+++ b/testcase/unittest/blockchain/conftest.py
@@ -126,21 +126,6 @@ def icon_preinvoke() -> dict:
             }
         },
         "currentRepsHash": "1d04dd2ccd9a9d14416d6878a8aa09e02334cd4afa964d75993f2e991ee874de",
-        "prep": {
-            "nextReps": [
-                {
-                    "id": "hx86aba2210918a9b116973f3c4b27c41a54d5dafe",
-                    "p2pEndpoint": "123.45.67.89:7100"
-                },
-                {
-                    "id": "hx13aca3210918a9b116973f3c4b27c41a54d5dad1",
-                    "p2pEndPoint": "210.34.56.17:7100"
-                }
-            ],
-            "irep": "0x1",
-            "state": "0x0",
-            "rootHash": "c7ffc6f8bf1ed76651c14756a061d662f580ff4de43b49fa82d80a4b80f8434a"
-        }
     }
 
 
@@ -182,7 +167,7 @@ def icon_invoke() -> dict:
             }
         },
         "prep": {
-            "preps": [
+            "nextReps": [
                 {
                     "id": "hx86aba2210918a9b116973f3c4b27c41a54d5dafe",
                     "p2pEndpoint": "123.45.67.89:7100"

--- a/testcase/unittest/blockchain/conftest.py
+++ b/testcase/unittest/blockchain/conftest.py
@@ -104,9 +104,9 @@ def tx_factory(tx_builder_factory) -> TxFactory:
 
 @pytest.fixture
 def icon_preinvoke() -> dict:
-    """Get queried data from ICON-Service.
+    """Suppose that I request PreInvoke to ICON-Service.
 
-    TODO: Check that the all data have valid key and value, especially hash prefix!
+    Note that no value will be returned before Rev. 6.
     """
 
     return {

--- a/testcase/unittest/blockchain/test_invoke_result.py
+++ b/testcase/unittest/blockchain/test_invoke_result.py
@@ -438,26 +438,18 @@ class TestInvokePool:
 
         StubCollection().icon_score_stubs = {}
 
-    def test_preinvoke(self, icon_preinvoke, icon_invoke: dict, invoke_pool):
+    def test_preinvoke(self, icon_preinvoke, invoke_pool):
         block_height = 1
         block_hash = Hash32.new()
-        epoch_num = 1
-        round_num = 1
-
-        # GIVEN I have no invoke data
-        with pytest.raises(KeyError):
-            invoke_pool.get_invoke_data(epoch_num, round_num)
 
         # WHEN I call prepare invoke
-        invoke_pool.prepare_invoke(
+        response = invoke_pool.prepare_invoke(
             block_height=block_height,
-            block_hash=block_hash,
-            epoch_num=epoch_num,
-            round_num=round_num
+            block_hash=block_hash
         )
 
-        # THEN The pool should create invoke data
-        assert invoke_pool.get_invoke_data(epoch_num, round_num)
+        # FIXME
+        assert isinstance(response, PreInvokeResponse)
 
     def test_genesis_invoke(self, invoke_pool, genesis_block: 'Block'):
         # GIVEN I have no invoke data

--- a/testcase/unittest/blockchain/test_invoke_result.py
+++ b/testcase/unittest/blockchain/test_invoke_result.py
@@ -299,7 +299,7 @@ class TestInvokeData:
         invoke_data: InvokeData = InvokeData.from_dict(
             epoch_num=epoch_num,
             round_num=round_num,
-            pre_invoke_result=icon_preinvoke
+            invoke_result=icon_preinvoke
         )
 
         # THEN It should contain required data
@@ -316,7 +316,7 @@ class TestInvokeData:
         invoke_data: InvokeData = InvokeData.from_dict(
             epoch_num=1,
             round_num=1,
-            pre_invoke_result=icon_preinvoke
+            invoke_result=icon_preinvoke
         )
         # THEN It should tell why validators list has been changed
         reason = invoke_data.changed_reason
@@ -336,7 +336,7 @@ class TestInvokeData:
         invoke_data: InvokeData = InvokeData.from_dict(
             epoch_num=1,
             round_num=1,
-            pre_invoke_result=icon_preinvoke
+            invoke_result=icon_preinvoke
         )
 
         # THEN Prep list is not changed
@@ -353,7 +353,7 @@ class TestInvokeData:
         invoke_data: InvokeData = InvokeData.from_dict(
             epoch_num=1,
             round_num=1,
-            pre_invoke_result=icon_preinvoke
+            invoke_result=icon_preinvoke
         )
 
         # AND It should not contain receipts and its hash at first,

--- a/testcase/unittest/blockchain/test_invoke_result.py
+++ b/testcase/unittest/blockchain/test_invoke_result.py
@@ -6,7 +6,7 @@ import pytest
 from loopchain import ChannelService
 from loopchain.blockchain import BlockBuilder
 from loopchain.blockchain.blocks import NextRepsChangeReason
-from loopchain.blockchain.invoke_result import InvokeRequest, InvokeData, InvokePool
+from loopchain.blockchain.invoke_result import InvokeRequest, InvokeData, InvokePool, PreInvokeResponse
 from loopchain.blockchain.transactions import Transaction, TransactionVersioner, TransactionSerializer
 from loopchain.blockchain.types import ExternalAddress, Hash32, Signature
 from loopchain.blockchain.votes.v1_0.vote import BlockVote
@@ -267,6 +267,28 @@ class TestInvokeRequest:
 
         # THEN Invoke Message should be identical as I expected
         assert invoke_request_dict == expected_request
+
+
+class TestPreInvokeResponse:
+    def test_from_dict(self, icon_preinvoke):
+        response = PreInvokeResponse.from_dict(icon_preinvoke)
+
+        assert response.validators_hash.hex_0x() == "0x1d04dd2ccd9a9d14416d6878a8aa09e02334cd4afa964d75993f2e991ee874de"
+        assert response.added_transactions == {
+            "6804dd2ccd9a9d17136d687838aa09e02334cd4afa964d75993f18991ee874de": {
+                "version": "0x3",
+                "timestamp": "0x563a6cf330136",
+                "dataType": "base",
+                "data": {
+                    "prep": {
+                        "incentive": "0x1",
+                        "rewardRate": "0x1",
+                        "totalDelegation": "0x3872423746291",
+                        "value": "0x7800000"
+                    }
+                }
+            }
+        }
 
 
 class TestInvokeData:

--- a/testcase/unittest/blockchain/test_invoke_result.py
+++ b/testcase/unittest/blockchain/test_invoke_result.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from loopchain.blockchain import BlockBuilder
+from loopchain.blockchain.blocks import BlockBuilder
 from loopchain.blockchain.blocks.v1_0 import Block, BlockHeader, BlockBody
 from loopchain.blockchain.invoke_result import InvokeRequest, InvokeData, InvokePool, PreInvokeResponse
 from loopchain.blockchain.transactions import Transaction, TransactionVersioner, TransactionSerializer

--- a/testcase/unittest/blockchain/votes/v1_0/test_vote_factory.py
+++ b/testcase/unittest/blockchain/votes/v1_0/test_vote_factory.py
@@ -19,14 +19,13 @@ class TestVoteFactory:
         """Suppose that caller of verifier proceeds invoke."""
 
         def _(invoke_pool: InvokePool, epoch_num: int, round_num: int):
-            invoke_data: InvokeData = InvokeData(
-                epoch_num=epoch_num, round_num=round_num,
-                added_transactions={},
-                validators_hash=Hash32.fromhex("0xea2254afbeaa13c73b6f366bfc7621e2a155df9e3ee1e1e7c00df5345c84a7af"),
-                next_validators_origin={}
+            invoke_data: InvokeData = InvokeData.new(
+                epoch_num=epoch_num,
+                round_num=round_num,
+                height=1,
+                current_validators_hash=Hash32.fromhex("0xea2254afbeaa13c73b6f366bfc7621e2a155df9e3ee1e1e7c00df5345c84a7af"),
+                invoke_result=icon_invoke
             )
-            invoke_data.height = 1
-            invoke_data.add_invoke_result(icon_invoke)
             invoke_pool.add_message(invoke_data)
 
             return invoke_data


### PR DESCRIPTION
# Changes
- Add PreInvokeResponse: Represent a data returned from IS PreInvoke
- No dependency of `InvokeData` to PreInvoke function when `BlockFactory.create_data`
- Replace mocked PreInvoke method (calling PreInvoke method actually)
- Change temporary name: query -> pre_invoke
- **and.. Always be with tests.**


## Relations between friends
![image](https://user-images.githubusercontent.com/36752264/86322058-35ead780-bc75-11ea-98bf-a3463c903765.png)
