### PR TITLE
[LC-991] Write precommit state after Block 1.0

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -558,13 +558,15 @@ class BlockChain:
                   block: Block,
                   confirm_info=None,
                   need_to_write_tx_info=True,
-                  need_to_score_invoke=True) -> bool:
+                  need_to_score_invoke=True,
+                  force_write_block=False) -> bool:
         """
 
         :param block:
         :param confirm_info: additional info for this block, but It came from next block of this block.
         :param need_to_write_tx_info:
         :param need_to_score_invoke:
+        :param force_write_block:
         :return:
         """
         with self.__add_block_lock:
@@ -572,9 +574,10 @@ class BlockChain:
                     not self.prevent_next_block_mismatch(block.header.height):
                 return True
 
-            return self.__add_block(block, confirm_info, need_to_write_tx_info, need_to_score_invoke)
+            return self.__add_block(block, confirm_info, need_to_write_tx_info, need_to_score_invoke, force_write_block)
 
-    def __add_block(self, block: Block, confirm_info, need_to_write_tx_info=True, need_to_score_invoke=True):
+    def __add_block(self, block: Block, confirm_info, need_to_write_tx_info=True, need_to_score_invoke=True,
+                    force_write_block=False):
         with self.__add_block_lock:
             channel_service = ObjectManager().channel_service
 
@@ -589,7 +592,7 @@ class BlockChain:
             next_total_tx = self.__write_block_data(block, confirm_info, receipts, next_prep)
 
             try:
-                if need_to_score_invoke:
+                if force_write_block or need_to_score_invoke:
                     channel_service.score_write_precommit_state(block)
             except Exception as e:
                 utils.exit_and_msg(f"score_write_precommit_state FAIL {e}")

--- a/loopchain/consensus/runner.py
+++ b/loopchain/consensus/runner.py
@@ -80,7 +80,7 @@ class ConsensusRunner(EventRegister):
             except KeyError:
                 utils.logger.warning(f"Block({round_end_event.commit_id}) does not exists in Consensus's DataPool.")
             else:
-                blockchain.add_block(block=block, need_to_score_invoke=False)
+                blockchain.add_block(block=block, need_to_score_invoke=False, force_write_block=True)
 
     # FIXME: Temporary
     async def _round_start(self, event: RoundEndEvent):


### PR DESCRIPTION
# Current situation
- #517 makes a node to invoke genesis block 1.0
- Invoke succeeds but state is not changed. (Tx result is not applied to state DB)

# Reason
- `BlockChain.add_block` has a flag named `need_to_score_invoke`, which enables score_invoke **AND** write_precommit_state.
- Loopchain 3.0 does not supply this flag as true due to invoking block outside of `BlockChain.add_block`, so avoids calling `write_precommit_state`.
 