### PR TITLE
[LC-1016] Prune InvokeResult after adding block

### DIFF
--- a/loopchain/consensus/runner.py
+++ b/loopchain/consensus/runner.py
@@ -38,7 +38,7 @@ class ConsensusRunner(EventRegister):
         self._invoke_pool: InvokePool = InvokePool()
         self.broadcast_scheduler = broadcast_scheduler
         self.event_system = event_system
-        self._block_factory: 'BlockFactory' = BlockFactory(
+        self._block_factory: BlockFactory = BlockFactory(
             epoch_pool_with_app=EpochPool(),
             tx_queue=tx_queue,
             blockchain=self._block_manager.blockchain,
@@ -204,6 +204,7 @@ class ConsensusRunner(EventRegister):
                 blockchain.add_block(
                     block=block, confirm_info=confirm_info, need_to_score_invoke=False, force_write_block=True
                 )
+                self._invoke_pool.prune_message(block.header.epoch, block.header.round)
 
     def _invoke_if_not(self, block: "Block"):
         try:

--- a/testcase/unittest/blockchain/test_invoke_result.py
+++ b/testcase/unittest/blockchain/test_invoke_result.py
@@ -425,6 +425,54 @@ class TestInvokePool:
             body
         )
 
+    def test_prune_invoke_result_until_target_round(self, invoke_pool):
+        epoch_num = 0
+        last_round = 10
+
+        # GIVEN I have many invoke data in invoke pool
+        assert not invoke_pool._messages
+        for i in range(last_round+1):
+            invoke_data = InvokeData(
+                epoch_num=epoch_num, round_num=i,
+                # Ignore params in this test
+                height=1, receipts=[], validators_hash=Hash32.empty(), state_root_hash=Hash32.empty()
+            )
+            invoke_pool.add_message(invoke_data)
+
+        # WHEN I prune all things except one
+        invoke_pool.prune_message(latest_epoch_num=0, latest_round_num=last_round)
+
+        # THEN I have only one invoke data
+        assert len(invoke_pool._messages) == 1
+        # AND Its round should be the last round
+        invoke_data = invoke_pool.get_invoke_data(epoch_num=epoch_num, round_num=last_round)
+        assert invoke_data.epoch_num == epoch_num
+        assert invoke_data.round_num == last_round
+
+    def test_prune_result_until_target_epoch(self, invoke_pool):
+        epoch_num = 0
+        last_round = 10
+
+        # GIVEN I have many invoke data in invoke pool
+        assert not invoke_pool._messages
+        for i in range(last_round+1):
+            invoke_data = InvokeData(
+                epoch_num=epoch_num, round_num=i,
+                # Ignore params in this test
+                height=1, receipts=[], validators_hash=Hash32.empty(), state_root_hash=Hash32.empty()
+            )
+            invoke_pool.add_message(invoke_data)
+
+        # WHEN I prune all things except one
+        invoke_pool.prune_message(latest_epoch_num=0, latest_round_num=last_round)
+
+        # THEN I have only one invoke data
+        assert len(invoke_pool._messages) == 1
+        # AND Its round should be the last round
+        invoke_data = invoke_pool.get_invoke_data(epoch_num=epoch_num, round_num=last_round)
+        assert invoke_data.epoch_num == epoch_num
+        assert invoke_data.round_num == last_round
+
     def test_preinvoke(self, icon_preinvoke, invoke_pool):
         # WHEN I call prepare invoke
         response: PreInvokeResponse = invoke_pool.prepare_invoke(


### PR DESCRIPTION
# Goal
- Prune InvokePool messages (results of IS invoke) right after writing Block in DB.
