### PR TITLE
[LC-1017] fix typo and remove unnecessary code line

### DIFF
--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -349,7 +349,7 @@ class BlockManager:
                         self.request_result_for_async[block_height] = \
                             await self._block_request_by_citizen_async(block_height, max_height)
                     else:
-                        await asyncio.sleep(conf.CITIZEN_ASYNC_REQUEST_WAITE)
+                        await asyncio.sleep(conf.CITIZEN_ASYNC_REQUEST_WAIT)
                         continue
 
                 response_code = self.request_result_for_async[block_height][-1]
@@ -370,7 +370,7 @@ class BlockManager:
 
                 peer_index = (peer_index + 1) % len(peer_stubs)
                 retry_time += 1
-                await asyncio.sleep(conf.CITIZEN_ASYNC_REQUEST_WAITE)
+                await asyncio.sleep(conf.CITIZEN_ASYNC_REQUEST_WAIT)
 
                 if retry_time > conf.CITIZEN_ASYNC_REQUEST_RETRY_TIMES:
                     util.exit_and_msg(f"This height({block_height}) can't get Block Information.")
@@ -562,7 +562,6 @@ class BlockManager:
                 continue
 
             if response_code == message_code.Response.success:
-                self.peer_target_for_async[process_height]
                 util.logger.debug(f"try add block height: {block.header.height}")
 
                 max_block_height = max(max_block_height, current_unconfirmed_block_height)


### PR DESCRIPTION
Fix typo.
 - Issue : The name of variable is different from the one in the configure file.

Remove unnecessary code line.