### PR TITLE
[LC-1024] Exit BlockSync when the current block is 1.0

### DIFF
--- a/loopchain/blockchain/blocks/block_versioner.py
+++ b/loopchain/blockchain/blocks/block_versioner.py
@@ -3,6 +3,7 @@ from collections import namedtuple
 from typing import List, Union
 
 from loopchain.blockchain.types import Hash32
+
 BlockVersion = namedtuple("BlockVersion", ("height", "name"))
 
 
@@ -31,6 +32,14 @@ class BlockVersioner:
             raise RuntimeError(f"There is no block version for the height. height: {height}")
         else:
             return version.name
+
+    def get_start_height(self, target_version: str) -> int:
+        try:
+            version = next(version for version in reversed(self._versions) if version.name == target_version)
+        except StopIteration:
+            raise RuntimeError(f"There is no block version. version: {target_version}")
+        else:
+            return version.height
 
     def get_height(self, block_dumped: Union[str, dict]):
         if isinstance(block_dumped, str):

--- a/loopchain/consensus/runner.py
+++ b/loopchain/consensus/runner.py
@@ -67,7 +67,7 @@ class ConsensusRunner(EventRegister):
         last_commit_block: Block = blockchain.last_block
 
         if last_commit_block:  # Not Genesis Block
-            commit_id = last_commit_block.header.hash
+            commit_id = last_commit_block.header.hash   # Could be Unrecorded Block (0.5)
             initial_blocks.append(last_commit_block)
 
             curr_epoch = LoopchainEpoch(

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -687,6 +687,19 @@ class BlockManager:
         try:
             max_height, unconfirmed_block_height, peer_stubs = self.__get_peer_stub_list()
 
+            if "1.0" in conf.CHANNEL_OPTION[self.channel_name].get("block_versions", {}).keys():
+                lft_start_height = conf.CHANNEL_OPTION[self.channel_name].get("block_versions", {})["1.0"]-1
+
+                if max_height > lft_start_height:
+                    util.logger.info(f"MaxHeight({max_height}) is block version 1.0. \
+                        So, Maxheight set max height of 0.5 ({lft_start_height}).")
+                    max_height = lft_start_height
+
+                if unconfirmed_block_height > lft_start_height:
+                    util.logger.info(f"Unconfirmed Height({max_height}_ is block version 1.0. \
+                        So, Unconfirmed Height set max height of 0.5 ({lft_start_height}).")
+                    unconfirmed_block_height = lft_start_height
+
             if self.blockchain.last_unconfirmed_block is not None:
                 self.candidate_blocks.remove_block(self.blockchain.last_unconfirmed_block.header.hash)
             self.blockchain.last_unconfirmed_block = None

--- a/loopchain/peer/block_manager.py
+++ b/loopchain/peer/block_manager.py
@@ -686,7 +686,9 @@ class BlockManager:
         # Make Peer Stub List [peer_stub, ...] and get max_height of network
         try:
             max_height, unconfirmed_block_height, peer_stubs = self.__get_peer_stub_list()
-            max_height, unconfirmed_block_height = self._limit_height_until_v1_0(max_height, unconfirmed_block_height)
+            height_before_lft: int = self.blockchain.block_versioner.get_start_height("1.0") - 1
+            max_height = min(height_before_lft, max_height)
+            unconfirmed_block_height = min(height_before_lft, unconfirmed_block_height)
 
             if self.blockchain.last_unconfirmed_block is not None:
                 self.candidate_blocks.remove_block(self.blockchain.last_unconfirmed_block.header.hash)
@@ -713,29 +715,10 @@ class BlockManager:
         else:
             util.logger.debug(f"block_height_sync is complete.")
             last_commit_block: Union[Block, Data] = self.blockchain.last_block
-            if last_commit_block and parse_version(last_commit_block.header.version) >= parse_version("1.0"):
+            if last_commit_block and last_commit_block.header.height == height_before_lft:
                 self.__channel_service.state_machine.start_lft()
             else:
                 self.__channel_service.state_machine.complete_sync()
-
-    def _limit_height_until_v1_0(self, max_height: int, unconfirmed_block_height: int) -> Tuple[int, int]:
-        block_versioner = self.blockchain.block_versioner
-        try:
-            height_before_lft: int = block_versioner.get_start_height("1.0") - 1
-        except RuntimeError as e:
-            util.logger.info(f"Block Version 1.0 Not Found. Skip updating BlockSync request height: {e}")
-        else:
-            if max_height > height_before_lft:
-                util.logger.info(f"MaxHeight({max_height}) is block version 1.0. \
-                        So, Maxheight set max height of 0.5 ({height_before_lft}).")
-                max_height = height_before_lft
-
-            if unconfirmed_block_height > height_before_lft:
-                util.logger.info(f"Unconfirmed Height({max_height}_ is block version 1.0. \
-                        So, Unconfirmed Height set max height of 0.5 ({height_before_lft}).")
-                unconfirmed_block_height = height_before_lft
-        finally:
-            return max_height, unconfirmed_block_height
 
     def get_next_leader(self) -> Optional[str]:
         """get next leader from last_block of BlockChain. for new_epoch and set_peer_type_in_channel

--- a/testcase/unittest/blockchain/blocks/test_block_versioner.py
+++ b/testcase/unittest/blockchain/blocks/test_block_versioner.py
@@ -1,0 +1,55 @@
+import pytest
+
+from loopchain.blockchain.blocks import BlockVersioner
+
+
+class TestBlockVersioner:
+    block_versions = {
+        "0.1a": 0,
+        "0.4": 10,
+        "0.5": 25,
+        "1.0": 40
+    }
+
+    @pytest.fixture
+    def block_versioner(self):
+        # GIVEN I have block versioner
+        block_versioner = BlockVersioner()
+
+        # AND I initialize it with block version info
+        for version, height in TestBlockVersioner.block_versions.items():
+            block_versioner.add_version(height, version)
+
+        return block_versioner
+
+    def test_get_version(self, block_versioner):
+        start_info: list = sorted(TestBlockVersioner.block_versions.items())
+        end_info = start_info[1:]
+        last_version, last_height = start_info[-1]
+        end_info.append((last_version, last_height+50))  # For last version test
+
+        # WHEN I get version by height...
+        for each_start, each_end in zip(start_info, end_info):
+            # From certain height of version...
+            start_ver, start_height = each_start
+            # Until the height whose version is supposed to be changed
+            end_ver, end_height = each_end
+
+            # THEN returned version should be start version
+            for height in range(start_height, end_height):
+                assert start_ver == block_versioner.get_version(height)
+
+    def test_get_start_height(self, block_versioner):
+        for version, height in TestBlockVersioner.block_versions.items():
+            assert height == block_versioner.get_start_height(version)
+
+    def test_get_start_height_invalid(self, block_versioner):
+        # GIVEN I have a block version
+        wrong_version = "0.7"
+        # AND It is not found in BlockVersioner
+        assert wrong_version not in TestBlockVersioner.block_versions.keys()
+
+        # WHEN I try to get height of wrong version
+        with pytest.raises(RuntimeError, match=f"no block version. version: {wrong_version}"):
+            # THEN Exception raises
+            block_versioner.get_start_height(wrong_version)


### PR DESCRIPTION
# Goal
- In BlockSync, no more request/sync blocks above 1.0 (1.0 height include)

