### PR TITLE
[LC-1034] Handle requestHeight for Consensus Sync

### DIFF
--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -608,9 +608,8 @@ class ChannelInnerTask:
 
         Responses last height of this node.
         """
-        last_block = self._channel_service.block_manager.blockchain.last_block
-        height: int = last_block.header.height
-        response_type = loopchain_pb2.HeightResponse(
+        height: int = self._channel_service.block_manager.blockchain.last_block.header.height
+        peer_height = loopchain_pb2.PeerHeight(
             peer=ChannelProperty().peer_target,
             channel=ChannelProperty().name,
             height=height
@@ -618,7 +617,7 @@ class ChannelInnerTask:
 
         channel = GRPCHelper().create_client_channel(request_from)
         stub = loopchain_pb2_grpc.PeerServiceStub(channel)
-        stub.BlockHeightResponse(response_type, conf.GRPC_TIMEOUT_SHORT)
+        stub.BlockHeightResponse(peer_height, conf.GRPC_TIMEOUT_SHORT)
 
     @message_queue_task(priority=255)
     async def block_height_response(self, peer: str, height: int):

--- a/loopchain/consensus/runner.py
+++ b/loopchain/consensus/runner.py
@@ -273,6 +273,10 @@ class ConsensusRunner(EventRegister):
         mediator = self.event_system.get_mediator(DelayedEventMediator)
         mediator.execute(0.5, round_start_event)
 
+    def update_status(self, peer: str, height: int):
+        # TODO: Update height info
+        pass
+
     _handler_prototypes = {
         BroadcastDataEvent: _on_event_broadcast_data,
         BroadcastVoteEvent: _on_event_broadcast_vote,

--- a/testcase/unittest/channel/test_inner.py
+++ b/testcase/unittest/channel/test_inner.py
@@ -1,0 +1,38 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from loopchain.baseservice.aging_cache import AgingCache
+from loopchain.channel.channel_inner_service import ChannelInnerTask
+from loopchain.channel.channel_service import ChannelService
+
+
+@pytest.mark.asyncio
+class TestChannelInnerTask:
+    # FIXME: dirty mocking
+
+    @pytest.fixture
+    def channel_inner_task(self):
+        channel_service = MagicMock(ChannelService)
+        tx_queue = MagicMock(AgingCache)
+
+        return ChannelInnerTask(
+            channel_service,
+            tx_queue
+        )
+
+    async def test_height_response_updates_height(self, channel_inner_task):
+        orig_func = channel_inner_task.block_height_response.__wrapped__
+
+        # GIVEN I got response
+        responding_peer = "123.123.123.123:7100"
+        responded_height = 100
+
+        # WHEN I triggered to update
+        await orig_func(channel_inner_task, responding_peer, responded_height)
+
+        # THEN consensus runner should update the current status
+        channel_service = channel_inner_task._channel_service
+        channel_service.consensus_runner.update_status.assert_called_with(
+            responding_peer, responded_height
+        )

--- a/testcase/unittest/peer/test_outer.py
+++ b/testcase/unittest/peer/test_outer.py
@@ -93,8 +93,8 @@ class TestHeightCommunication:
 
         # WHEN The node got response against BlockHeightRequest
         with ThreadPoolExecutor() as executor:
-            req_type = PeerHeight(channel=CHANNEL_NAME)
-            executor.submit(outer_service.BlockHeightResponse, req_type, "context")
+            peer_height = PeerHeight(channel=CHANNEL_NAME)
+            executor.submit(outer_service.BlockHeightResponse, peer_height, "context")
             await asyncio.sleep(.5)
 
         # THEN The node triggers correspond func

--- a/testcase/unittest/peer/test_outer.py
+++ b/testcase/unittest/peer/test_outer.py
@@ -1,0 +1,101 @@
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from typing import Callable
+from unittest.mock import MagicMock
+
+import pytest
+
+from loopchain import PeerService
+from loopchain.baseservice import ObjectManager
+from loopchain.channel.channel_inner_service import ChannelInnerStub, ChannelInnerTask
+from loopchain.peer import PeerOuterService
+from loopchain.protos import (
+    HeightRequest, PeerHeight
+)
+from loopchain.utils.message_queue import StubCollection
+
+CHANNEL_NAME = "test_channel"
+
+
+@pytest.fixture
+def mocking_object_manager():
+    peer_service = MagicMock(PeerService)
+    peer_service.inner_service.loop = asyncio.get_event_loop()
+
+    ObjectManager().peer_service = peer_service
+
+    yield
+
+    ObjectManager().peer_service = None
+
+
+@pytest.fixture
+def outer_service(mocking_object_manager):
+    return PeerOuterService()
+
+
+@pytest.fixture(autouse=True)
+def stub_collection():
+    orig_channel_stubs = StubCollection().channel_stubs
+
+    channel_stub = MagicMock(ChannelInnerStub)
+    channel_inner_task = MagicMock(ChannelInnerTask)
+    channel_stub.async_task.return_value = channel_inner_task
+
+    channel_stubs = {
+        CHANNEL_NAME: channel_stub
+    }
+
+    StubCollection().channel_stubs = channel_stubs
+
+    yield
+
+    StubCollection().channel_stubs = orig_channel_stubs
+
+
+@pytest.fixture
+def get_inner_task_checker() -> Callable[...,  MagicMock]:
+    def _mock_inner_task_func(func_name) -> MagicMock:
+        checker = MagicMock()
+
+        async def target_coro_double(*args, **kwargs):
+            return checker(*args, **kwargs)
+
+        channel_stub = StubCollection().channel_stubs[CHANNEL_NAME]
+        inner_task = channel_stub.async_task()
+        setattr(inner_task, func_name, target_coro_double)
+
+        return checker
+
+    return _mock_inner_task_func
+
+
+@pytest.mark.asyncio
+class TestHeightCommunication:
+    async def test_trigger_height_response_after_height_requested(self, outer_service, get_inner_task_checker):
+        # GIVEN Nothing is requested
+        checker = get_inner_task_checker("block_height_request")
+        assert not checker.call_count
+
+        # WHEN The node is requested BlockHeightRequest
+        with ThreadPoolExecutor() as executor:
+            req_type = HeightRequest(channel=CHANNEL_NAME)
+            executor.submit(outer_service.BlockHeightRequest, req_type, "context")
+            await asyncio.sleep(.5)
+
+        # THEN The node triggers correspond func
+        assert checker.call_count == 1
+
+    async def test_trigger_height_update_after_height_responded(self, outer_service, get_inner_task_checker):
+        # GIVEN Nothing is responded
+        checker = get_inner_task_checker("block_height_response")
+        assert not checker.call_count
+
+        # WHEN The node got response against BlockHeightRequest
+        with ThreadPoolExecutor() as executor:
+            req_type = PeerHeight(channel=CHANNEL_NAME)
+            executor.submit(outer_service.BlockHeightResponse, req_type, "context")
+            await asyncio.sleep(.5)
+
+        # THEN The node triggers correspond func
+        assert checker.call_count == 1


### PR DESCRIPTION
~(WIP: resolved after #559)~

# Goal
- if the node requested `BlockHeightRequest`, receive it first then response in other gRPC protocol `BlockHeightResponse`