### PR TITLE
Update requires compatible on Makefile

### DIFF
--- a/.github/workflows/citizen.yml
+++ b/.github/workflows/citizen.yml
@@ -42,18 +42,24 @@ jobs:
         cd -
         icon_rc -version
 
-    - name: Install Loopchain
+    - if: ${{ github.base_ref == 'master' }}
+      name: Install Loopchain master
+      run: |
+        pwd
+        make install
+
+    - if: ${{ github.base_ref != 'master' }}
+      name: Install Loopchain develop
       run: |
         pwd
         make develop
-
     - name: Generate-key
       run: |
-        sed "23 a\  \"PRIVATE_PASSWORD\": \"${pwd}\"," -i conf/mainnet/loopchain_conf.json
+        sed "23 a\  \"PRIVATE_PASSWORD\": \"${PWD}\"," -i conf/mainnet/loopchain_conf.json
         cat conf/mainnet/loopchain_conf.json
 
-        pip install tbears
-        tbears keystore -p ${pwd} my_keystore.json
+        python -c "import os; from iconsdk.wallet.wallet import KeyWallet; \
+          KeyWallet.create().store('my_keystore.json', os.getenv('PWD'))"
       env:
         pwd: Most_safest_pw_in_the_wor1d
 

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -16,7 +16,7 @@ jobs:
         echo "::set-env name=PR_PATH::https://github.com/${GITHUB_REPOSITORY}/pull/${pr_num}"
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.7
 

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ requirements:
 all: install generate-key
 
 requires:
-	$(PIP_INSTALL) iconservice==1.7.0
-	$(PIP_INSTALL) iconrpcserver==1.5.0
+	$(PIP_INSTALL) iconservice~=1.7.0
+	$(PIP_INSTALL) iconrpcserver~=1.5.0
 	$(PIP_INSTALL) tbears
 
 ## pip install packages

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ all: install generate-key
 requires:
 	$(PIP_INSTALL) iconservice~=1.7.0
 	$(PIP_INSTALL) iconrpcserver~=1.5.0
-	$(PIP_INSTALL) tbears
+	$(PIP_INSTALL) iconsdk~=1.3.0
 
 ## pip install packages
 install: $(INSTALL_REQUIRES)
@@ -64,7 +64,8 @@ generate-proto:
 ## Generate a key
 generate-key:
 	@file="my_keystore.json"; $(RM) $${file} > /dev/null; \
-	tbears keystore $${file}; \
+	python -c "import getpass; from iconsdk.wallet.wallet import KeyWallet; \
+		KeyWallet.create().store('$${file}', getpass.getpass('Input your keystore password: '))"; \
 	cat $${file}
 
 ## Check loopchain & gunicorn & rabbitmq processes

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup_options = {
     'setup_requires': setup_requires,
     'install_requires': install_requires,
     'extras_require': {
-        'tests': ['iconsdk==1.1.0', 'pytest>=4.6.3', 'pytest-xprocess>=0.12.1', "pytest-benchmark", "pytest-mock",
+        'tests': ['iconsdk~=1.3.0', 'pytest>=4.6.3', 'pytest-xprocess>=0.12.1', "pytest-benchmark", "pytest-mock",
                   "pytest-asyncio", "freezegun"],
     },
     'entry_points': {


### PR DESCRIPTION
Dependent libraries can be updated patch version.
This should not be hotfixed by dependent libraries.
And, this `hotfix` PR just update `Makefile` without update version.

- compatible version with iconservice 1.7.0, iconrpcserver 1.5.0