### PR TITLE
[LC-1039] Fix a bug when `url_input` is `None`.

### DIFF
--- a/loopchain/utils/__init__.py
+++ b/loopchain/utils/__init__.py
@@ -145,7 +145,7 @@ def normalize_request_url(url_input, version=None, channel=None):
     if url_input and 'http://' in url_input:
         url_input = url_input.split("http://")[1]
 
-    use_https = 'https://' in url_input
+    use_https = 'https://' in url_input if url_input else False
     if not url_input:  # ex) '' => http://localhost:9000/api/v3
         url = generate_url_from_params(version=version, channel=channel)
     elif use_https and url_input.count(':') == 1:  # ex) https://testwallet.icon.foundation

--- a/loopchain/utils/__init__.py
+++ b/loopchain/utils/__init__.py
@@ -146,7 +146,7 @@ def normalize_request_url(url_input, version=None, channel=None):
         url_input = url_input.split("http://")[1]
 
     use_https = 'https://' in url_input if url_input else False
-    if not url_input:  # ex) '' => http://localhost:9000/api/v3
+    if not url_input:  # ex) '' => http://127.0.0.1:9000/api/v3/icon_dex
         url = generate_url_from_params(version=version, channel=channel)
     elif use_https and url_input.count(':') == 1:  # ex) https://testwallet.icon.foundation
         url = generate_url_from_params(dns=url_input.split("https://")[1],

--- a/testcase/unittest/utils/test_util.py
+++ b/testcase/unittest/utils/test_util.py
@@ -1,0 +1,10 @@
+from loopchain import configure_default as conf
+from loopchain.utils import normalize_request_url
+
+
+class TestNormalizeRequestURL:
+    def test_get_local_endpoint_if_url_input_not_exist(self):
+        url_input = None
+        expected_result = f"http://127.0.0.1:{conf.PORT_PEER_FOR_REST}/api/v3/{conf.LOOPCHAIN_DEFAULT_CHANNEL}"
+
+        assert expected_result == normalize_request_url(url_input)


### PR DESCRIPTION
When `url_input` is `None`, the exception occurs `TypeError`. Because Nonetype is not iterable.