### PR TITLE
[LC-1041] Do Invoke before commit if not

### DIFF
--- a/loopchain/consensus/runner.py
+++ b/loopchain/consensus/runner.py
@@ -197,10 +197,17 @@ class ConsensusRunner(EventRegister):
                     epoch_num=candidate_block.header.epoch,
                     round_num=candidate_block.header.round
                 )
+                self._invoke_if_not(block)
                 self._write_candidate_info(candidate_block, candidate_votes)
                 blockchain.add_block(
                     block=block, confirm_info=confirm_info, need_to_score_invoke=False, force_write_block=True
                 )
+
+    def _invoke_if_not(self, block: "Block"):
+        try:
+            self._invoke_pool.get_invoke_data(block.header.epoch, block.header.round)
+        except KeyError:
+            self._invoke_pool.invoke(block)
 
     def _write_candidate_info(self, candidate_block: 'Block', candidate_votes: Sequence[BlockVote]):
         """Write candidate info in batch."""


### PR DESCRIPTION
# Issue Scenario
`Invoke` may not be execute in case of Consensus Sync in the scenario below:

## Given
- My node is turned off, so that I didn't participate in consensus process.
- Get a block and its votes from another node.
- Pass them to LFT
- RoundEnd with success

## When
- Try to write committed block

## Then
- Raises write precommit block error!

# ..Why?
- The requested votes are enought to confirm the block
- And it doesn't need my vote to commit it
- And Consensus engine skips its verification
- And Invoke on my node is also skipped.

# Goal
- Do invoke before commit if not invoked
