### PR TITLE
[LC-1042] Update last_unconfirmed_block on LFT consensus

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -1443,7 +1443,10 @@ class BlockChain:
 
         return block_builder
 
-    def try_update_last_unconfirmed_block(self, unconfirmed_block: 'Block'):
+    def try_update_last_unconfirmed_block(self, unconfirmed_block: 'Block') -> bool:
         """Note that the method expects an input as Block 1.0+"""
         if not self.__last_block or unconfirmed_block.header.height == self.__last_block.header.height + 2:
             self.last_unconfirmed_block = unconfirmed_block
+            return True
+
+        return False

--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -460,7 +460,7 @@ class BlockChain:
         """
         return self.__find_block_by_key(block_hash.hex().encode(encoding='UTF-8'))
 
-    def find_block_by_height(self, block_height):
+    def find_block_by_height(self, block_height) -> Optional['Block']:
         """find block in DB by its height
 
         :param block_height: int,
@@ -1442,3 +1442,8 @@ class BlockChain:
             self.__add_tx_to_block(block_builder)
 
         return block_builder
+
+    def try_update_last_unconfirmed_block(self, unconfirmed_block: 'Block'):
+        """Note that the method expects an input as Block 1.0+"""
+        if not self.__last_block or unconfirmed_block.header.height == self.__last_block.header.height + 2:
+            self.last_unconfirmed_block = unconfirmed_block

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -638,7 +638,7 @@ class ChannelInnerTask:
         blockchain = self._channel_service.block_manager.blockchain
         block: Optional[Block_V1_0] = blockchain.find_block_by_height(height)
         if not block:
-            return  # FIXME: Ignore response? or Send client to failure message?
+            return  # Requester should handle this case.
 
         block_dumped = self._channel_service.block_manager.blockchain.block_dumps(block)
         block_send = loopchain_pb2.BlockSend(

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -608,7 +608,7 @@ class ChannelInnerTask:
 
         Responses last height of this node.
         """
-        height: int = self._channel_service.block_manager.blockchain.last_block.header.height
+        height: int = self._channel_service.block_manager.blockchain.latest_block.header.height
         peer_height = loopchain_pb2.PeerHeight(
             peer=ChannelProperty().peer_target,
             channel=ChannelProperty().name,
@@ -636,7 +636,9 @@ class ChannelInnerTask:
         Note that BlockRequest allows only Block 1.0+
         """
         blockchain = self._channel_service.block_manager.blockchain
-        block: Block_V1_0 = blockchain.find_block_by_height(height)
+        block: Optional[Block_V1_0] = blockchain.find_block_by_height(height)
+        if not block:
+            return  # FIXME: Ignore response? or Send client to failure message?
 
         block_dumped = self._channel_service.block_manager.blockchain.block_dumps(block)
         block_send = loopchain_pb2.BlockSend(
@@ -686,6 +688,7 @@ class ChannelInnerTask:
             f"hash({unconfirmed_block.header.hash.hex()})")
 
         if self._channel_service.state_machine.state == "Consensus":
+            self._blockchain.try_update_last_unconfirmed_block(unconfirmed_block)
             self._channel_service.consensus_runner.receive_data(unconfirmed_block)
             return
 

--- a/loopchain/consensus/runner.py
+++ b/loopchain/consensus/runner.py
@@ -151,6 +151,8 @@ class ConsensusRunner(EventRegister):
         return tx_builder.build(False)
 
     async def _on_event_broadcast_data(self, event: BroadcastDataEvent):
+        self._block_manager.blockchain.try_update_last_unconfirmed_block(event.data)
+
         target_reps_hash = ChannelProperty().crep_root_hash  # FIXME
         self._block_manager.send_unconfirmed_block(
             block_=event.data,

--- a/loopchain/consensus/runner.py
+++ b/loopchain/consensus/runner.py
@@ -151,14 +151,13 @@ class ConsensusRunner(EventRegister):
         return tx_builder.build(False)
 
     async def _on_event_broadcast_data(self, event: BroadcastDataEvent):
-        self._block_manager.blockchain.try_update_last_unconfirmed_block(event.data)
-
-        target_reps_hash = ChannelProperty().crep_root_hash  # FIXME
-        self._block_manager.send_unconfirmed_block(
-            block_=event.data,
-            target_reps_hash=target_reps_hash,
-            round_=event.data.round_num
-        )
+        if self._block_manager.blockchain.try_update_last_unconfirmed_block(event.data):
+            target_reps_hash = ChannelProperty().crep_root_hash  # FIXME
+            self._block_manager.send_unconfirmed_block(
+                block_=event.data,
+                target_reps_hash=target_reps_hash,
+                round_=event.data.round_num
+            )
 
     async def _on_event_broadcast_vote(self, event: BroadcastVoteEvent):
         vote_dumped = self._vote_dumps(event.vote)


### PR DESCRIPTION
# Goal
- `BlockHeightRequest` now triggers to return highest block height, contains `last_unconfirmed_block`
- `BlockRequest`now triggers to return highest block, contains `last_unconfirmed_block`
- Update BlockChain.last_unconfirmed_block in receiving or broadcasting any block.

# Why `last_unconfirmed_block` needed?
- Nodes need to exchange informations each other, not only known (committed) info, but unknown (needs to be voted) info!
