### PR TITLE
[LC-1046] Remove unconfirmed transactions after committed

### DIFF
--- a/loopchain/blockchain/blockchain.py
+++ b/loopchain/blockchain/blockchain.py
@@ -606,6 +606,10 @@ class BlockChain:
 
             return self.__add_block(block, confirm_info, need_to_write_tx_info, need_to_score_invoke, force_write_block)
 
+    @property
+    def invoke_results(self):
+        return self.__invoke_results
+
     def __add_block(self, block: 'Block', confirm_info, need_to_write_tx_info=True, need_to_score_invoke=True,
                     force_write_block=False):
         with self.__add_block_lock:

--- a/loopchain/blockchain/invoke_result.py
+++ b/loopchain/blockchain/invoke_result.py
@@ -244,6 +244,10 @@ class InvokeData(Message):
 
 
 class InvokePool(MessagePool):
+    def __init__(self, blockchain):
+        super(InvokePool, self).__init__()
+        self._blockchain = blockchain
+
     def get_invoke_data(self, epoch_num: int, round_num: int) -> InvokeData:
         id_ = f"{epoch_num}_{round_num}".encode()
 
@@ -277,7 +281,18 @@ class InvokePool(MessagePool):
         )
         self.add_message(invoke_data)
 
+        self._process_invoke_results_legacy(block, invoke_result_dict)
+
         return invoke_data
+
+    def _process_invoke_results_legacy(self, block: 'Block', invoke_result_dict: dict):
+        """Temporary"""
+
+        tx_receipts = invoke_result_dict["txResults"]
+        for tx_receipt in tx_receipts:
+            tx_receipt["blockHash"] = block.header.hash.hex()
+
+        self._blockchain.invoke_results[block.header.hash] = (tx_receipts, None)
 
     def genesis_invoke(self, block: 'Block') -> InvokeData:
         method = "icx_sendTransaction"

--- a/loopchain/consensus/runner.py
+++ b/loopchain/consensus/runner.py
@@ -31,11 +31,11 @@ class ConsensusRunner(EventRegister):
                  event_system: 'EventSystem',
                  tx_queue: 'AgingCache',
                  broadcast_scheduler: 'BroadcastScheduler',
-                 block_manager):
+                 block_manager: 'BlockManager'):
         super().__init__(event_system.simulator)
 
         self._block_manager: 'BlockManager' = block_manager
-        self._invoke_pool: InvokePool = InvokePool()
+        self._invoke_pool: InvokePool = InvokePool(block_manager.blockchain)
         self.broadcast_scheduler = broadcast_scheduler
         self.event_system = event_system
         self._block_factory: 'BlockFactory' = BlockFactory(

--- a/testcase/unittest/blockchain/test_invoke_result.py
+++ b/testcase/unittest/blockchain/test_invoke_result.py
@@ -1,9 +1,11 @@
+import os
 from collections import OrderedDict
 from typing import List, Callable, cast
 from unittest.mock import MagicMock
 
 import pytest
 
+from loopchain.blockchain import BlockChain
 from loopchain.blockchain.blocks import BlockBuilder
 from loopchain.blockchain.blocks.v1_0 import Block, BlockHeader, BlockBody
 from loopchain.blockchain.invoke_result import InvokeRequest, InvokeData, InvokePool, PreInvokeResponse
@@ -382,7 +384,7 @@ class TestInvokePool:
 
     @pytest.fixture
     def invoke_pool(self):
-        return InvokePool()
+        return InvokePool(blockchain=MagicMock(BlockChain))
 
     @pytest.fixture(autouse=True)
     def mock_channel_name(self):
@@ -416,6 +418,7 @@ class TestInvokePool:
         header.height = TestInvokePool.height
         header.epoch = TestInvokePool.epoch_num
         header.round = TestInvokePool.round_num
+        header.hash = Hash32(os.urandom(32))
         header.validators_hash = TestInvokePool.current_validators_hash
 
         body = cast(BlockBody, MagicMock(BlockBody))

--- a/testcase/unittest/blockchain/votes/v1_0/test_vote_factory.py
+++ b/testcase/unittest/blockchain/votes/v1_0/test_vote_factory.py
@@ -1,8 +1,10 @@
 import os
 from typing import Callable
+from unittest.mock import MagicMock
 
 import pytest
 
+from loopchain.blockchain import BlockChain
 from loopchain.blockchain.invoke_result import InvokeData, InvokePool
 from loopchain.blockchain.types import Hash32, ExternalAddress
 from loopchain.blockchain.votes.v1_0 import BlockVote, BlockVoteFactory
@@ -12,7 +14,7 @@ from loopchain.crypto.signature import Signer
 class TestVoteFactory:
     @pytest.fixture
     def invoke_pool(self) -> InvokePool:
-        return InvokePool()
+        return InvokePool(MagicMock(BlockChain))
 
     @pytest.fixture
     def mock_verify(self, icon_invoke) -> Callable[[InvokePool, int, int], InvokeData]:


### PR DESCRIPTION
# Goal
- Use **`Blockchain.__invoke_results`** to remove confirmed transactions.

# Why this happened
- In loopchain 3.0, the class who invokes does not record invoke result
- In under 3.0, invoked result recored temporarely under `Blockchain.__invoke_results`
- when confirmed txs are written, check each txs in that var, to pop out from AgingCache (unconfirmed transaction queue).
> So I make `InvokePool` to store required values like what current consensus engine does.
