### PR TITLE
[IS-1234] fixed bug that leader complain timer has triggered

### DIFF
--- a/loopchain/channel/channel_service.py
+++ b/loopchain/channel/channel_service.py
@@ -564,6 +564,7 @@ class ChannelService:
         utils.logger.spam(f"reset_leader target({leader_peer_target}), complained={complained}")
 
         if complained:
+            self.stop_leader_complain_timer()
             self.__block_manager.blockchain.reset_leader_made_block_count()
             self.__block_manager.epoch.new_round(new_leader_id)
 


### PR DESCRIPTION
 This bug may occurs after leader changed. If leader `complained`, stop
 the complain timer immediately.