### PR TITLE
[IS-1233] confirm block sequentially when received simultaneously

### DIFF
--- a/.github/workflows/citizen.yml
+++ b/.github/workflows/citizen.yml
@@ -12,8 +12,8 @@ jobs:
     - name: Variable Settings
       run: |
         pr_num=$(echo ${GITHUB_REF} | cut -d "/" -f 3)
-        echo "::set-env name=LOG_PATH::https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-        echo "::set-env name=PR_PATH::https://github.com/${GITHUB_REPOSITORY}/pull/${pr_num}"
+        echo "LOG_PATH=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_ENV
+        echo "PR_PATH=https://github.com/${GITHUB_REPOSITORY}/pull/${pr_num}" >> $GITHUB_ENV
 
     - name: Setup Python
       uses: actions/setup-python@v1

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -12,8 +12,8 @@ jobs:
     - name: Variable Settings
       run: |
         pr_num=$(echo ${GITHUB_REF} | cut -d "/" -f 3)
-        echo "::set-env name=LOG_PATH::https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-        echo "::set-env name=PR_PATH::https://github.com/${GITHUB_REPOSITORY}/pull/${pr_num}"
+        echo "LOG_PATH=https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_ENV
+        echo "PR_PATH=https://github.com/${GITHUB_REPOSITORY}/pull/${pr_num}" >> $GITHUB_ENV
 
     - name: Setup Python
       uses: actions/setup-python@v2
@@ -35,7 +35,7 @@ jobs:
       run: |
         pip install -e .[tests]
 
-    - name:
+    - name: Test
       run: |
         make unit-test
 

--- a/loopchain/channel/channel_inner_service.py
+++ b/loopchain/channel/channel_inner_service.py
@@ -654,11 +654,6 @@ class ChannelInnerTask:
             util.logger.debug("BlockChain has not been initialized yet.")
             return
 
-        if not self._block_manager.confirm_event.is_set():
-            util.logger.debug(f"confirm_event waiting at unconfirmed BH({unconfirmed_block.header.height})")
-            await self._block_manager.confirm_event.wait()
-            util.logger.debug(f"confirm_event released at unconfirmed BH({unconfirmed_block.header.height})")
-
         try:
             self._block_manager.verify_confirm_info(unconfirmed_block)
         except ConfirmInfoInvalid as e:
@@ -675,7 +670,6 @@ class ChannelInnerTask:
         except NotReadyToConfirmInfo as e:
             util.logger.warning(f"{e!r}")
         else:
-            self._block_manager.confirm_event.clear()
             self._channel_service.state_machine.vote(unconfirmed_block=unconfirmed_block, round_=round_)
 
     @message_queue_task

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -152,8 +152,7 @@ class ChannelStateMachine(object):
     def _do_vote(self, unconfirmed_block: Block, round_: int):
         if unconfirmed_block.header.is_unrecorded:
             try:
-                self._run_coroutine_threadsafe(
-                    self.__channel_service.block_manager.add_unconfirmed_block(unconfirmed_block, round_))
+                self.__channel_service.block_manager.add_unconfirmed_block(unconfirmed_block, round_)
             except UnrecordedBlock as e:
                 util.logger.info(e)
             except InvalidUnconfirmedBlock as e:

--- a/loopchain/channel/channel_statemachine.py
+++ b/loopchain/channel/channel_statemachine.py
@@ -158,8 +158,7 @@ class ChannelStateMachine(object):
             except InvalidUnconfirmedBlock as e:
                 util.logger.spam(f"The Unrecorded block is unnecessary to vote.")
         else:
-            self._run_coroutine_threadsafe(
-                self.__channel_service.block_manager.vote_as_peer(unconfirmed_block, round_))
+            self.__channel_service.block_manager.vote_as_peer(unconfirmed_block, round_)
 
     def _consensus_on_enter(self, *args, **kwargs):
         self.block_height_sync()


### PR DESCRIPTION
- change `vote_as_peer()` as function from coroutine
- flow single blocking logic when announce_unconfirmed_block
- fixed http request timeout(5 sec) to search block sync target